### PR TITLE
Fixed generator issue / tests for Python3.5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,7 @@
 build/
 dist/
 *.egg-info/
+
+# Pycharm directories 
+.idea
+.ropeproject/

--- a/src/pybreaker.py
+++ b/src/pybreaker.py
@@ -315,7 +315,7 @@ class CircuitBreakerState(object):
 
     def generator_call(self, wrapped_generator):
         try:
-            value = yield wrapped_generator.next()
+            value = yield next(wrapped_generator)
             while True:
                 value = yield wrapped_generator.send(value)
         except StopIteration:

--- a/src/tests.py
+++ b/src/tests.py
@@ -419,12 +419,12 @@ class CircuitBreakerTestCase(unittest.TestCase):
 
         s = suc(True)
         e = err(True)
-        e.next()
+        next(e)
+
         self.assertRaises(NotImplementedError, e.send, True)
         self.assertEqual(1, self.breaker.fail_counter)
-
-        self.assertTrue(s.next())
-        self.assertRaises(StopIteration, s.next)
+        self.assertTrue(next(s))
+        self.assertRaises(StopIteration, lambda: next(s))
         self.assertEqual(0, self.breaker.fail_counter)
 
 
@@ -550,3 +550,4 @@ class CircuitBreakerThreadsTestCase(unittest.TestCase):
         self.breaker.add_listener(SleepListener())
         self._start_threads(trigger_error, 3)
         self.assertEqual(self.breaker.fail_max, self.breaker.fail_counter)
+


### PR DESCRIPTION
.next() has been renamed to __next__() in Python3. Due to this issue the generator functions / tests could not be executed in Python3.5. 
Also the assertRaises test required a lambda function to have the next statement executed to be able to raise the exception.  