### PR TITLE
Wrapped function is called twice during successful call in open state

### DIFF
--- a/src/pybreaker.py
+++ b/src/pybreaker.py
@@ -410,7 +410,16 @@ class CircuitOpenState(CircuitBreakerState):
             raise CircuitBreakerError(error_msg)
         else:
             self._breaker.half_open()
-            self._breaker.call(func, *args, **kwargs)
+            return self._breaker.call(func, *args, **kwargs)
+
+    def call(self, func, *args, **kwargs):
+        """
+        Delegate the call to before_call, if the time out is not elapsed it will throw an exception, otherwise we get
+        the results from the call performed after the state is switch to half-open
+        """
+
+        return self.before_call(func, *args, **kwargs)
+
 
 
 class CircuitHalfOpenState(CircuitBreakerState):

--- a/src/tests.py
+++ b/src/tests.py
@@ -1,10 +1,10 @@
 #-*- coding:utf-8 -*-
 
 from pybreaker import *
-from random import random
 from time import sleep
 
 import unittest
+import unittest.mock
 
 
 class CircuitBreakerTestCase(unittest.TestCase):
@@ -157,11 +157,11 @@ class CircuitBreakerTestCase(unittest.TestCase):
 
     def test_successful_after_timeout(self):
         """CircuitBreaker: it should close the circuit when a call succeeds
-        after timeout.
+        after timeout. The successful function should only be called once.
         """
         self.breaker = CircuitBreaker(fail_max=3, reset_timeout=0.5)
 
-        def suc(): return True
+        suc = unittest.mock.MagicMock(return_value=True)
         def err(): raise NotImplementedError()
 
         self.assertRaises(NotImplementedError, self.breaker.call, err)
@@ -180,6 +180,7 @@ class CircuitBreakerTestCase(unittest.TestCase):
         self.assertTrue(self.breaker.call(suc))
         self.assertEqual(0, self.breaker.fail_counter)
         self.assertEqual('closed', self.breaker.current_state)
+        self.assertEqual(1, suc.call_count)
 
     def test_failed_call_when_halfopen(self):
         """CircuitBreaker: it should open the circuit when a call fails in
@@ -551,3 +552,6 @@ class CircuitBreakerThreadsTestCase(unittest.TestCase):
         self._start_threads(trigger_error, 3)
         self.assertEqual(self.breaker.fail_max, self.breaker.fail_counter)
 
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
When the circuit breaker is open:
cb.call() delegates to CircuitOpenState.call() which is not implemented so the parent CircuitBreakerState.call() is called.
This function calls CircuitOpenState.before_call() and then call the wrapped function.

CircuitOpenState.before_call() switch the state of the CB to half open and then calls cb.call(), which in turn delegates to CircuitHalfOpenState.call() which is not implemented so we go back to CircuitBreakerState.call() which eventually calls the wrapped function a second time (from a timeline perspective this is actually the first call)

I updated a testcase to illustrate the issue and propose a solution.