### PR TITLE
Add travis config & fix test reference

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+language: python
+python:
+  - "2.7"
+  - "3.2"
+  - "3.3"
+  - "3.4"
+  - "3.5"
+  - "3.6"
+script: python setup.py test

--- a/src/tests.py
+++ b/src/tests.py
@@ -161,7 +161,7 @@ class CircuitBreakerTestCase(unittest.TestCase):
         """
         self.breaker = CircuitBreaker(fail_max=3, reset_timeout=0.5)
 
-        suc = unittest.mock.MagicMock(return_value=True)
+        suc = mock.MagicMock(return_value=True)
         def err(): raise NotImplementedError()
 
         self.assertRaises(NotImplementedError, self.breaker.call, err)


### PR DESCRIPTION
When running the tests, found (what appears to be) an artifact of the cleanup in c046c2f. Also added a travis config since I've found that helpful in the past - I can split up this PR as well if the travis config doesn't make sense.

A passing build can be found here: https://travis-ci.org/phillbaker/pybreaker/builds/214252529