### PR TITLE
Add redis-backed storage class.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -23,6 +23,7 @@ Features
 * Can guard generator functions
 * Functions and properties for easy monitoring and management
 * Thread-safe
+* Optional redis backing
 
 
 Requirements
@@ -64,10 +65,32 @@ integration point you want to protect against::
 e.g., live across requests.
 
 .. note::
-  
+
   Integration points to external services (i.e. databases, queues, etc) are
   more likely to fail, so make sure to always use timeouts when accessing such
   services if there's support at the API level.
+
+If you'd like to use the Redis backing, initialize the ``CircuitBreaker`` with a ``CircuitRedisStorage``::
+
+    import pybreaker
+    import redis
+
+    redis = redis.StrictRedis()
+    db_breaker = pybreaker.CircuitBreaker(
+        fail_max=5,
+        reset_timeout=60,
+        state_storage=CircuitRedisStorage('closed', redis))
+
+.. note::
+
+  You may want to reuse a connection already created in your application, if you're using ``django_redis`` for example::
+
+    from django_redis import get_redis_connection
+
+    db_breaker = pybreaker.CircuitBreaker(
+        fail_max=5,
+        reset_timeout=60,
+        state_storage=CircuitRedisStorage('closed', get_redis_connection('default')))
 
 
 Event Listening

--- a/setup.py
+++ b/setup.py
@@ -30,5 +30,5 @@ setup(
     include_package_data = True,
     zip_safe = False,
     test_suite = 'tests',
-    tests_require=['mock'],
+    tests_require=['mock', 'fakeredis', 'redis'],
 )

--- a/src/pybreaker.py
+++ b/src/pybreaker.py
@@ -9,12 +9,17 @@ book at http://pragprog.com/titles/mnee/release-it
 """
 
 import types
+import time
+import calendar
+import logging
 from datetime import datetime, timedelta
 from functools import wraps
 
 import threading
 
-__all__ = ('CircuitBreaker', 'CircuitBreakerListener', 'CircuitBreakerError', 'CircuitMemoryStorage',)
+__all__ = (
+    'CircuitBreaker', 'CircuitBreakerListener', 'CircuitBreakerError',
+    'CircuitMemoryStorage', 'CircuitRedisStorage',)
 
 
 class CircuitBreaker(object):
@@ -361,6 +366,138 @@ class CircuitMemoryStorage(CircuitBreakerStorage):
         `datetime`.
         """
         self._opened_at = datetime
+
+
+class CircuitRedisStorage(CircuitBreakerStorage):
+    """
+    Implements a `CircuitBreakerStorage` using redis.
+    """
+
+    BASE_NAMESPACE = 'pybreaker'
+
+    logger = logging.getLogger(__name__)
+
+    try:
+        from redis.exceptions import RedisError
+    except ImportError:
+        # Module does not exist, so this feature is not available
+        raise ImportError("CircuitRedisStorage can only be used if the required dependencies exist")
+
+    def __init__(self, state, redis_object, namespace=None, fallback_circuit_state='closed'):
+        """
+        Creates a new instance with the given `state` and `redis` object. The
+        redis object should be similar to pyredis' StrictRedis class. If there
+        are any connection issues with redis, the `fallback_circuit_state` is
+        used to determine the state of the circuit.
+        """
+        super(CircuitRedisStorage, self).__init__('redis')
+
+        self._redis = redis_object
+        self._namespace_name = namespace
+        self._fallback_circuit_state = fallback_circuit_state
+
+        self._redis.setnx(self._namespace('fail_counter'), 0)
+        self._redis.setnx(self._namespace('state'), str(state))
+
+    @property
+    def state(self):
+        """
+        Returns the current circuit breaker state.
+        """
+        try:
+            return self._redis.get(self._namespace('state')).decode('utf-8')
+        except self.RedisError:
+            self.logger.error('RedisError: falling back to default circuit state', exc_info=True)
+            return self._fallback_circuit_state
+
+    @state.setter
+    def state(self, state):
+        """
+        Set the current circuit breaker state to `state`.
+        """
+        try:
+            self._redis.set(self._namespace('state'), str(state))
+        except self.RedisError:
+            self.logger.error('RedisError', exc_info=True)
+            pass
+
+    def increment_counter(self):
+        """
+        Increases the failure counter by one.
+        """
+        try:
+            self._redis.incr(self._namespace('fail_counter'))
+        except self.RedisError:
+            self.logger.error('RedisError', exc_info=True)
+            pass
+
+    def reset_counter(self):
+        """
+        Sets the failure counter to zero.
+        """
+        try:
+            self._redis.set(self._namespace('fail_counter'), 0)
+        except self.RedisError:
+            self.logger.error('RedisError', exc_info=True)
+            pass
+
+    @property
+    def counter(self):
+        """
+        Returns the current value of the failure counter.
+        """
+        try:
+            value = self._redis.get(self._namespace('fail_counter'))
+            if value:
+                return int(value)
+            else:
+                return 0
+        except self.RedisError:
+            self.logger.error('RedisError: Assuming no errors', exc_info=True)
+            return 0
+
+    @property
+    def opened_at(self):
+        """
+        Returns a datetime object of the most recent value of when the circuit
+        was opened.
+        """
+        try:
+            timestamp = self._redis.get(self._namespace('opened_at'))
+            if timestamp:
+                return datetime(*time.gmtime(int(timestamp))[:6])
+        except self.RedisError:
+            self.logger.error('RedisError', exc_info=True)
+            return None
+
+    @opened_at.setter
+    def opened_at(self, now):
+        """
+        Atomically sets the most recent value of when the circuit was opened
+        to `now`. Stored in redis as a simple integer of unix epoch time.
+        To avoid timezone issues between different systems, the passed in
+        datetime should be in UTC.
+        """
+        try:
+            key = self._namespace('opened_at')
+            def set_if_greater(pipe):
+                current_value = pipe.get(key)
+                next_value = int(calendar.timegm(now.timetuple()))
+                pipe.multi()
+                if not current_value or next_value > int(current_value):
+                    pipe.set(key, next_value)
+
+            self._redis.transaction(set_if_greater, key)
+        except self.RedisError:
+            self.logger.error('RedisError', exc_info=True)
+            pass
+
+    def _namespace(self, key):
+        name_parts = [self.BASE_NAMESPACE, key]
+        if self._namespace_name:
+            name_parts.insert(0, self._namespace_name)
+
+        return ':'.join(name_parts)
 
 
 class CircuitBreakerListener(object):


### PR DESCRIPTION
* Allows keys to be namespaced
* On failure of redis, uses a fallback state (defaults to closed, ie allowing calls through)
* Separates the tests into mixins to be tested against different storage backends (sorry the diff is hard to read).
 
Questions:
* What do you think about logging the connection failures (so they're not totally invisible)?
* The current code should handle some concurrency - e.g. incrementing the counter at the same time or setting the opened_at timestamp at the same time, in cases where locking is done in local memory, what are your thoughts on translating that to Redis?

Remaining work:
- [x] finish tests covering new functionality of Redis backing
- [x] add concurrency tests for redis, similar to `CircuitBreakerThreadsTestCase`