### PR TITLE
Move import of redis into `CircuitRedisStorage.__init__`

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -79,7 +79,7 @@ If you'd like to use the Redis backing, initialize the ``CircuitBreaker`` with a
     db_breaker = pybreaker.CircuitBreaker(
         fail_max=5,
         reset_timeout=60,
-        state_storage=CircuitRedisStorage('closed', redis))
+        state_storage=pybreaker.CircuitRedisStorage('closed', redis))
 
 .. note::
 

--- a/src/pybreaker.py
+++ b/src/pybreaker.py
@@ -377,12 +377,6 @@ class CircuitRedisStorage(CircuitBreakerStorage):
 
     logger = logging.getLogger(__name__)
 
-    try:
-        from redis.exceptions import RedisError
-    except ImportError:
-        # Module does not exist, so this feature is not available
-        raise ImportError("CircuitRedisStorage can only be used if the required dependencies exist")
-
     def __init__(self, state, redis_object, namespace=None, fallback_circuit_state='closed'):
         """
         Creates a new instance with the given `state` and `redis` object. The
@@ -391,6 +385,12 @@ class CircuitRedisStorage(CircuitBreakerStorage):
         used to determine the state of the circuit.
         """
         super(CircuitRedisStorage, self).__init__('redis')
+
+        try:
+            self.RedisError = __import__('redis').exceptions.RedisError
+        except ImportError:
+            # Module does not exist, so this feature is not available
+            raise ImportError("CircuitRedisStorage can only be used if 'redis' is available")
 
         self._redis = redis_object
         self._namespace_name = namespace


### PR DESCRIPTION
Should close https://github.com/danielfm/pybreaker/issues/16.

Not sure how to write a test for this, I couldn't get the test environment to _not_ install redis. But I did test this locally and it seemed to work better.