### PR TITLE
Add optional support for calling Tornado coroutines

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,5 +30,5 @@ setup(
     include_package_data = True,
     zip_safe = False,
     test_suite = 'tests',
-    tests_require=['mock', 'fakeredis', 'redis'],
+    tests_require=['mock', 'fakeredis', 'redis', 'tornado'],
 )

--- a/src/pybreaker.py
+++ b/src/pybreaker.py
@@ -227,18 +227,18 @@ class CircuitBreaker(object):
         Returns a wrapper that calls the function `func` according to the rules
         implemented by the current state of this circuit breaker.
 
-        Optionally takes the keyword argument `call_future`, which will will
-        call `func` as a Tornado co-routine.
+        Optionally takes the keyword argument `__pybreaker_call_coroutine`,
+        which will will call `func` as a Tornado co-routine.
         """
-        call_future = kwargs.pop('call_future', False)
+        call_async = kwargs.pop('__pybreaker_call_async', False)
 
-        if call_future and not HAS_TORNADO_SUPPORT:
+        if call_async and not HAS_TORNADO_SUPPORT:
             raise ImportError('No module named tornado')
 
         def _outer_wrapper(func):
             @wraps(func)
             def _inner_wrapper(*args, **kwargs):
-                if call_future:
+                if call_async:
                     return self.call_async(func, *args, **kwargs)
                 return self.call(func, *args, **kwargs)
             return _inner_wrapper

--- a/src/pybreaker.py
+++ b/src/pybreaker.py
@@ -222,7 +222,7 @@ class CircuitBreaker(object):
             self._state_storage.state = 'closed'
             self._state = CircuitClosedState(self, self._state, notify=True)
 
-    def __call__(self, *args, **kwargs):
+    def __call__(self, *call_args, **call_kwargs):
         """
         Returns a wrapper that calls the function `func` according to the rules
         implemented by the current state of this circuit breaker.
@@ -230,7 +230,7 @@ class CircuitBreaker(object):
         Optionally takes the keyword argument `__pybreaker_call_coroutine`,
         which will will call `func` as a Tornado co-routine.
         """
-        call_async = kwargs.pop('__pybreaker_call_async', False)
+        call_async = call_kwargs.pop('__pybreaker_call_async', False)
 
         if call_async and not HAS_TORNADO_SUPPORT:
             raise ImportError('No module named tornado')
@@ -243,8 +243,8 @@ class CircuitBreaker(object):
                 return self.call(func, *args, **kwargs)
             return _inner_wrapper
 
-        if args:
-            return _outer_wrapper(*args)
+        if call_args:
+            return _outer_wrapper(*call_args)
         return _outer_wrapper
 
     @property

--- a/src/tests.py
+++ b/src/tests.py
@@ -476,13 +476,13 @@ class CircuitBreakerConfigurationTestCase(object):
     def test_decorator_call_future(self):
         """CircuitBreaker: it should be a decorator.
         """
-        @self.breaker(call_future=True)
+        @self.breaker(__pybreaker_call_async=True)
         @gen.coroutine
         def suc(value):
             "Docstring"
             raise gen.Return(value)
 
-        @self.breaker(call_future=True)
+        @self.breaker(__pybreaker_call_async=True)
         @gen.coroutine
         def err(value):
             "Docstring"
@@ -506,7 +506,7 @@ class CircuitBreakerConfigurationTestCase(object):
     def test_no_tornado_raises(self):
         with self.assertRaises(ImportError):
             def func(): return True
-            self.breaker(func, call_future=True)
+            self.breaker(func, __pybreaker_call_async=True)
 
 
 class CircuitBreakerTestCase(testing.AsyncTestCase, CircuitBreakerStorageBasedTestCase, CircuitBreakerConfigurationTestCase):


### PR DESCRIPTION
I'm a big fan of your library and I've been using my own fork over here at SeatGeek, so I figured I'd contribute. We use Tornado as our webserver and use this code to circuit break asynchronous code.  

This change adds optional support for Tornado coroutines. This should be a backwards compatible change. 

I did this by:
- Modifying `CircuitBreaker.__call__` to optionally take a keyword argument `__pybreaker_call_async`, which will call `CircuitBreaker.call_async` if `True`. The keyword argument is sufficiently verbose to hopefully avoid collision with existing keyword arguments
- Adding `CircuitBreaker.call_async`
- Adding `CircuitBreakerState.call_async`
- Duplicating the import pattern used by HAS_REDIS_SUPPORT 

This also has tests that cover the parts that I added. It also fixes a bug if `redis` is not present.