### PR TITLE
Get initial CircuitBreaker state from state_storage

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+Version 0.4.1 (September 28, 2017)
+
+* Get initial CircuitBreaker state from state_storage (Thanks @alukach!)
+=========
+
 Version 0.4.0 (June 23, 2017)
 
 * Added optional support for asynchronous Tornado calls (Thanks @jeffrand!)

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup
 
 setup(
     name='pybreaker',
-    version='0.4.0',
+    version='0.4.1',
     description='Python implementation of the Circuit Breaker pattern',
     long_description=open('README.rst', 'r').read(),
     keywords=['design', 'pattern', 'circuit', 'breaker', 'integration'],

--- a/src/pybreaker.py
+++ b/src/pybreaker.py
@@ -119,9 +119,8 @@ class CircuitBreaker(object):
         try:
             return state_map[state](self, state, notify=notify)
         except KeyError:
-            raise ValueError(
-                "Unknown state (%r), valid states: %s",
-                state, ', '.join(state_map.keys()))
+            msg = "Unknown state {!r}), valid states: {}"
+            raise ValueError(msg.format(state, ', '.join(state_map)))
 
     @property
     def state(self):

--- a/src/tests.py
+++ b/src/tests.py
@@ -256,7 +256,7 @@ class CircuitBreakerConfigurationTestCase(object):
         for state in (STATE_OPEN, STATE_CLOSED, STATE_HALF_OPEN):
             storage = CircuitMemoryStorage(state)
             breaker = CircuitBreaker(state_storage=storage)
-            self.assertEqual(breaker._state.name, state)
+            self.assertEqual(breaker.state.name, state)
 
     def test_default_params(self):
         """CircuitBreaker: it should define smart defaults.
@@ -526,6 +526,24 @@ class CircuitBreakerTestCase(testing.AsyncTestCase, CircuitBreakerStorageBasedTe
         super(CircuitBreakerTestCase, self).setUp()
         self.breaker_kwargs = {}
         self.breaker = CircuitBreaker()
+
+    def test_create_new_state__bad_state(self):
+        with self.assertRaises(ValueError):
+            self.breaker._create_new_state('foo')
+
+    @mock.patch('pybreaker.CircuitOpenState')
+    def test_notify_not_called_on_init(self, open_state):
+        storage = CircuitMemoryStorage('open')
+        breaker = CircuitBreaker(state_storage=storage)
+        open_state.assert_called_once_with(breaker, 'open', notify=False)
+
+    @mock.patch('pybreaker.CircuitOpenState')
+    def test_notify_called_on_state_change(self, open_state):
+        storage = CircuitMemoryStorage('closed')
+        breaker = CircuitBreaker(state_storage=storage)
+        storage.state = 'open'
+        breaker.state
+        open_state.assert_called_once_with(breaker, 'open', notify=True)
 
 
 import fakeredis

--- a/src/tests.py
+++ b/src/tests.py
@@ -535,15 +535,15 @@ class CircuitBreakerTestCase(testing.AsyncTestCase, CircuitBreakerStorageBasedTe
     def test_notify_not_called_on_init(self, open_state):
         storage = CircuitMemoryStorage('open')
         breaker = CircuitBreaker(state_storage=storage)
-        open_state.assert_called_once_with(breaker, 'open', notify=False)
+        open_state.assert_called_once_with(breaker, prev_state=None, notify=False)
 
     @mock.patch('pybreaker.CircuitOpenState')
     def test_notify_called_on_state_change(self, open_state):
         storage = CircuitMemoryStorage('closed')
         breaker = CircuitBreaker(state_storage=storage)
-        storage.state = 'open'
-        breaker.state
-        open_state.assert_called_once_with(breaker, 'open', notify=True)
+        prev_state = breaker.state
+        breaker.state = 'open'
+        open_state.assert_called_once_with(breaker, prev_state=prev_state, notify=True)
 
 
 import fakeredis

--- a/src/tests.py
+++ b/src/tests.py
@@ -250,6 +250,14 @@ class CircuitBreakerConfigurationTestCase(object):
     Tests for the CircuitBreaker class.
     """
 
+    def test_default_state(self):
+        """CircuitBreaker: it should get initial state from state_storage.
+        """
+        for state in (STATE_OPEN, STATE_CLOSED, STATE_HALF_OPEN):
+            storage = CircuitMemoryStorage(state)
+            breaker = CircuitBreaker(state_storage=storage)
+            self.assertEqual(breaker._state.name, state)
+
     def test_default_params(self):
         """CircuitBreaker: it should define smart defaults.
         """


### PR DESCRIPTION
The PR intends to resolve danielfm/pybreak#26 by altering the `CircuitBreaker` to make no assumptions about an initialized `CircuitBreaker` state. Instead, on first call of `breaker.state`, the state is retrieved from the `state_storage`. This allows `pybreaker` to play nicely in environments where it is desirable share `CircuitBreaker` state between machines.