### PR TITLE
Do not reset fail count in CircuitBreaker creation

### DIFF
--- a/src/pybreaker.py
+++ b/src/pybreaker.py
@@ -742,8 +742,13 @@ class CircuitClosedState(CircuitBreakerState):
         Moves the given circuit breaker `cb` to the "closed" state.
         """
         super(CircuitClosedState, self).__init__(cb, STATE_CLOSED)
-        self._breaker._state_storage.reset_counter()
         if notify:
+            # We only reset the counter if notify is True, otherwise the CircuitBreaker
+            # will lose it's failure count due to a second CircuitBreaker being created
+            # using the same _state_storage object, or if the _state_storage objects
+            # share a central source of truth (as would be the case with the redis
+            # storage).
+            self._breaker._state_storage.reset_counter()
             for listener in self._breaker.listeners:
                 listener.state_change(self._breaker, prev_state, self)
 

--- a/src/tests.py
+++ b/src/tests.py
@@ -545,6 +545,15 @@ class CircuitBreakerTestCase(testing.AsyncTestCase, CircuitBreakerStorageBasedTe
         breaker.state = 'open'
         open_state.assert_called_once_with(breaker, prev_state=prev_state, notify=True)
 
+    def test_failure_count_not_reset_during_creation(self):
+        for state in (STATE_OPEN, STATE_CLOSED, STATE_HALF_OPEN):
+            storage = CircuitMemoryStorage(state)
+            storage.increment_counter()
+
+            breaker = CircuitBreaker(state_storage=storage)
+            self.assertEqual(breaker.state.name, state)
+            self.assertEqual(breaker.fail_counter, 1)
+
 
 import fakeredis
 import logging


### PR DESCRIPTION
The current CircuitBreaker code currently correctly detects the current
state from the provided state storage object and uses it to construct
the internal state object. However when the detected state is "closed",
the newly instantiated `CircuitClosedState` will reset the fail counter
on the breaker.

These changes move the `reset_counter()` call into the notify block.

This issue was called out in #26, but was not addressed in #27.