### PR TITLE
Add trigger exception into the CircuitBreakerError

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,9 @@ setup(
     url='http://github.com/danielfm/pybreaker',
     package_dir={'': 'src'},
     py_modules=['pybreaker'],
+    install_requires=[
+        'six',
+    ],
     include_package_data=True,
     zip_safe=False,
     test_suite='tests',

--- a/src/pybreaker.py
+++ b/src/pybreaker.py
@@ -15,6 +15,8 @@ import logging
 from datetime import datetime, timedelta
 from functools import wraps
 import threading
+import six
+import sys
 
 try:
     from tornado import gen
@@ -776,7 +778,7 @@ class CircuitClosedState(CircuitBreakerState):
             self._breaker.open()
 
             error_msg = 'Failures threshold reached, circuit breaker opened'
-            raise CircuitBreakerError(error_msg)
+            six.reraise(CircuitBreakerError, CircuitBreakerError(error_msg), sys.exc_info()[2])
 
 
 class CircuitOpenState(CircuitBreakerState):
@@ -846,7 +848,8 @@ class CircuitHalfOpenState(CircuitBreakerState):
         Opens the circuit breaker.
         """
         self._breaker.open()
-        raise CircuitBreakerError('Trial call failed, circuit breaker opened')
+        error_msg = 'Trial call failed, circuit breaker opened'
+        six.reraise(CircuitBreakerError, CircuitBreakerError(error_msg), sys.exc_info()[2])
 
     def on_success(self):
         """

--- a/src/tests.py
+++ b/src/tests.py
@@ -1,17 +1,14 @@
 #-*- coding:utf-8 -*-
-import pytest
-import sys
-
-from pytest import fail
-
-from pybreaker import *
-from time import sleep
 
 import unittest
-import mock
+from time import sleep
 
+import mock
+from pytest import fail
 from tornado import gen
 from tornado import testing
+
+from pybreaker import *
 
 
 class CircuitBreakerStorageBasedTestCase(object):
@@ -53,7 +50,21 @@ class CircuitBreakerStorageBasedTestCase(object):
         self.assertEqual('closed', self.breaker.current_state)
 
     def test_several_failed_calls(self):
-        """CircuitBreaker: it should open the circuit after many failures, the traceback should have trigger exception
+        """CircuitBreaker: it should open the circuit after many failures.
+        """
+        self.breaker = CircuitBreaker(fail_max=3, **self.breaker_kwargs)
+        def func(): raise NotImplementedError()
+
+        self.assertRaises(NotImplementedError, self.breaker.call, func)
+        self.assertRaises(NotImplementedError, self.breaker.call, func)
+
+        # Circuit should open
+        self.assertRaises(CircuitBreakerError, self.breaker.call, func)
+        self.assertEqual(3, self.breaker.fail_counter)
+        self.assertEqual('open', self.breaker.current_state)
+
+    def test_traceback_in_circuitbreaker_error(self):
+        """CircuitBreaker: it should open the circuit after many failures.
         """
         self.breaker = CircuitBreaker(fail_max=3, **self.breaker_kwargs)
         def func(): raise NotImplementedError()

--- a/src/tests.py
+++ b/src/tests.py
@@ -1,4 +1,8 @@
 #-*- coding:utf-8 -*-
+import pytest
+import sys
+
+from pytest import fail
 
 from pybreaker import *
 from time import sleep
@@ -58,7 +62,12 @@ class CircuitBreakerStorageBasedTestCase(object):
         self.assertRaises(NotImplementedError, self.breaker.call, func)
 
         # Circuit should open
-        self.assertRaises(CircuitBreakerError, self.breaker.call, func)
+        try:
+            self.breaker.call(func)
+            fail('CircuitBreakerError should throw')
+        except CircuitBreakerError as e:
+            import traceback
+            self.assertIn('NotImplementedError', traceback.format_exc())
         self.assertEqual(3, self.breaker.fail_counter)
         self.assertEqual('open', self.breaker.current_state)
 

--- a/src/tests.py
+++ b/src/tests.py
@@ -53,7 +53,7 @@ class CircuitBreakerStorageBasedTestCase(object):
         self.assertEqual('closed', self.breaker.current_state)
 
     def test_several_failed_calls(self):
-        """CircuitBreaker: it should open the circuit after many failures.
+        """CircuitBreaker: it should open the circuit after many failures, the traceback should have trigger exception
         """
         self.breaker = CircuitBreaker(fail_max=3, **self.breaker_kwargs)
         def func(): raise NotImplementedError()


### PR DESCRIPTION
When using python 2.7, the trigger exception is lost when the CB's threshold breaches and CB's in half-open status and failed on the retry.