### PR TITLE
Fix bug with timeout window growing as additional breakers are defined

### DIFF
--- a/src/pybreaker.py
+++ b/src/pybreaker.py
@@ -229,6 +229,7 @@ class CircuitBreaker(object):
         until timeout elapses.
         """
         with self._lock:
+            self._state_storage.opened_at = datetime.utcnow()
             self.state = self._state_storage.state = STATE_OPEN
 
     def half_open(self):
@@ -813,7 +814,6 @@ class CircuitOpenState(CircuitBreakerState):
         Moves the given circuit breaker `cb` to the "open" state.
         """
         super(CircuitOpenState, self).__init__(cb, STATE_OPEN)
-        self._breaker._state_storage.opened_at = datetime.utcnow()
         if notify:
             for listener in self._breaker.listeners:
                 listener.state_change(self._breaker, prev_state, self)

--- a/src/tests.py
+++ b/src/tests.py
@@ -1,6 +1,7 @@
 #-*- coding:utf-8 -*-
 
 import unittest
+from datetime import datetime
 from time import sleep
 
 import mock
@@ -585,6 +586,17 @@ class CircuitBreakerTestCase(testing.AsyncTestCase, CircuitBreakerStorageBasedTe
             breaker = CircuitBreaker(state_storage=storage)
             self.assertEqual(breaker.state.name, state)
             self.assertEqual(breaker.fail_counter, 1)
+
+    def test_state_opened_at_not_reset_during_creation(self):
+        for state in (STATE_OPEN, STATE_CLOSED, STATE_HALF_OPEN):
+            storage = CircuitMemoryStorage(state)
+            now = datetime.now()
+            storage.opened_at = now
+
+            breaker = CircuitBreaker(state_storage=storage)
+            self.assertEqual(breaker.state.name, state)
+            self.assertEqual(storage.opened_at, now)
+
 
 
 import fakeredis


### PR DESCRIPTION
We discovered a bug in the circuit breaker logic that updates the `opened_at` value for the storage state as new processes spin up and initialize that state. The consequence of this is that we can inadvertently extend the timeout window for an open circuit indefinitely if new processes spin up more frequently than the timeout configured.

This fix moves the setting of the `opened_at` time to `CircuitBreaker.open()` so that it gets set only when the breaker opens and not when the `CircuitBreakerState` is instantiated (which can happen without an attempt to call the function wrapped).