### PR TITLE
Fix travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,5 +15,5 @@ matrix:
         - os: linux
           python: 3.6
 install:
-    - if [[ $TRAVIS_PYTHON_VERSION == '3.2' ]]; then travis_retry pip install tornado==4.1; fi
+    - if [[ $TRAVIS_PYTHON_VERSION == '3.2' || $TRAVIS_PYTHON_VERSION == '3.3' ]]; then travis_retry pip install tornado==4.1; else travis_retry pip install 'tornado==5.*'; fi
 script: python setup.py test

--- a/setup.py
+++ b/setup.py
@@ -33,5 +33,5 @@ setup(
     include_package_data=True,
     zip_safe=False,
     test_suite='tests',
-    tests_require=['mock', 'fakeredis', 'redis', 'tornado'],
+    tests_require=['mock', 'fakeredis==0.16.0', 'redis==2.10.6', 'tornado'],
 )


### PR DESCRIPTION
The Travis build is broken at present due to two issues:

a) Tornado 5 has dropped Python 3.3 support
b) redis & fakeredis have both seen updates that cause dependency version conflicts

This fixes (a) by applying similar behaviour as is already in place for Python 3.2, and (b) by locking the dependency versions to those used in the last successful builds.