### PR TITLE
Add Python 3.7 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,10 @@ matrix:
           python: 3.5
         - os: linux
           python: 3.6
+        - os: linux
+          python: 3.7
+          dist: xenial
+          sudo: true
 install:
     - if [[ $TRAVIS_PYTHON_VERSION == '3.2' || $TRAVIS_PYTHON_VERSION == '3.3' ]]; then travis_retry pip install tornado==4.1; else travis_retry pip install 'tornado==5.*'; fi
 script: python setup.py test

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,5 +15,5 @@ matrix:
         - os: linux
           python: 3.6
 install:
-    - if [[ $TRAVIS_PYTHON_VERSION == '3.2' ]]; then travis_retry pip install tornado==4.1; fi
+    - if [[ $TRAVIS_PYTHON_VERSION == '3.2' || $TRAVIS_PYTHON_VERSION == '3.3' ]]; then travis_retry pip install tornado==4.1; else travis_retry pip install 'tornado==5.*'; fi
 script: python setup.py test

--- a/setup.py
+++ b/setup.py
@@ -33,5 +33,5 @@ setup(
     include_package_data=True,
     zip_safe=False,
     test_suite='tests',
-    tests_require=['mock', 'fakeredis', 'redis', 'tornado'],
+    tests_require=['mock', 'fakeredis==0.16.0', 'redis==2.10.6', 'tornado'],
 )

--- a/src/tests.py
+++ b/src/tests.py
@@ -262,7 +262,7 @@ class CircuitBreakerStorageBasedTestCase(object):
         self.assertRaises(NotImplementedError, e.send, True)
         self.assertEqual(1, self.breaker.fail_counter)
         self.assertTrue(next(s))
-        self.assertRaises(StopIteration, lambda: next(s))
+        self.assertRaises((StopIteration, RuntimeError), lambda: next(s))
         self.assertEqual(0, self.breaker.fail_counter)
 
 


### PR DESCRIPTION
This adds a Travis build for Python 3.7, and fixes a test assertions where the behaviour was broken due to the [PEP 479](https://www.python.org/dev/peps/pep-0479/) changes to StopIteration (this doesn't appear to affect the behaviour, just the test).

This depends on #37.