### PR TITLE
Allow filter functions to be used for excluded exceptions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -216,6 +216,14 @@ In that case, when any function guarded by that circuit breaker raises
 ``CustomerValidationError`` (or any exception derived from
 ``CustomerValidationError``), that call won't be considered a system failure.
 
+So as to cover cases where the exception class alone is not enough to determine
+whether it represents a system error, you may also pass a callable rather than
+a type::
+
+    db_breaker = CircuitBreaker(exclude=[lambda e: type(e) == HTTPError and e.status_code < 500])
+
+You may mix types and filter callables freely.
+
 
 Monitoring and Management
 `````````````````````````

--- a/src/pybreaker.py
+++ b/src/pybreaker.py
@@ -195,10 +195,14 @@ class CircuitBreaker(object):
         system malfunction. Business exceptions should not cause this circuit
         breaker to open.
         """
-        texc = type(exception)
-        for exc in self._excluded_exceptions:
-            if issubclass(texc, exc):
-                return False
+        exception_type = type(exception)
+        for exclusion in self._excluded_exceptions:
+            if type(exclusion) is type:
+                if issubclass(exception_type, exclusion):
+                    return False
+            elif callable(exclusion):
+                if exclusion(exception):
+                    return False
         return True
 
     def call(self, func, *args, **kwargs):


### PR DESCRIPTION
This PR changes the excluded exceptions list to allow a mix of exception types and callable functions, so as to allow for more fine-grained filtering of system exceptions.

This covers cases such as [Bottle's](https://bottlepy.org/) `HTTPError`, where the same exception is used to cover both client errors (HTTP 4xx) and server exceptions (HTTP 5xx). We don't wish to increment the failure counter in cases where we're proxying a request that may cause a client error (e.g. a 404) - hence passing a filter function allows us to differentiate the different uses of this exception type.