### PR TITLE
Allow concurrent execution of wrapped method

### DIFF
--- a/src/tests.py
+++ b/src/tests.py
@@ -682,8 +682,7 @@ class CircuitBreakerThreadsTestCase(unittest.TestCase):
         setattr(obj, func.__name__, MethodType(func, self.breaker))
 
     def test_fail_thread_safety(self):
-        """CircuitBreaker: it should compute a failed call atomically to
-        avoid race conditions.
+        """CircuitBreaker: it should increment the fail counter atomically.
         """
         # Create a specific exception to avoid masking other errors
         class SpecificException(Exception):
@@ -698,36 +697,12 @@ class CircuitBreakerThreadsTestCase(unittest.TestCase):
                 except SpecificException: pass
 
         def _inc_counter(self):
-            c = self._state_storage._fail_counter
             sleep(0.00005)
-            self._state_storage._fail_counter = c + 1
+            self._state_storage.increment_counter()
 
         self._mock_function(self.breaker, _inc_counter)
         self._start_threads(trigger_error, 3)
         self.assertEqual(1500, self.breaker.fail_counter)
-
-    def test_success_thread_safety(self):
-        """CircuitBreaker: it should compute a successful call atomically
-        to avoid race conditions.
-        """
-        @self.breaker
-        def suc(): return True
-
-        def trigger_success():
-            for n in range(500):
-                suc()
-
-        class SuccessListener(CircuitBreakerListener):
-            def success(self, cb):
-                c = 0
-                if hasattr(cb, '_success_counter'):
-                    c = cb._success_counter
-                sleep(0.00005)
-                cb._success_counter = c + 1
-
-        self.breaker.add_listener(SuccessListener())
-        self._start_threads(trigger_success, 3)
-        self.assertEqual(1500, self.breaker._success_counter)
 
     def test_half_open_thread_safety(self):
         """CircuitBreaker: it should allow only one trial call when the
@@ -765,7 +740,9 @@ class CircuitBreakerThreadsTestCase(unittest.TestCase):
 
     def test_fail_max_thread_safety(self):
         """CircuitBreaker: it should not allow more failed calls than
-        'fail_max' setting.
+        'fail_max' setting. As up to num_threads will potentially be executing
+        concurrently, we can get concurrent updates such that the
+        counter is greater than the 'fail_max' by the number of threads.
         """
         @self.breaker
         def err(): raise Exception()
@@ -780,8 +757,9 @@ class CircuitBreakerThreadsTestCase(unittest.TestCase):
                 sleep(0.00005)
 
         self.breaker.add_listener(SleepListener())
-        self._start_threads(trigger_error, 3)
-        self.assertEqual(self.breaker.fail_max, self.breaker.fail_counter)
+        num_threads = 3
+        self._start_threads(trigger_error, num_threads)
+        self.assertLess(self.breaker.fail_max, self.breaker.fail_counter + num_threads)
 
 
 class CircuitBreakerRedisConcurrencyTestCase(unittest.TestCase):
@@ -813,8 +791,7 @@ class CircuitBreakerRedisConcurrencyTestCase(unittest.TestCase):
         setattr(obj, func.__name__, MethodType(func, self.breaker))
 
     def test_fail_thread_safety(self):
-        """CircuitBreaker: it should compute a failed call atomically to
-        avoid race conditions.
+        """CircuitBreaker: it should increment the fail counter atomically.
         """
         # Create a specific exception to avoid masking other errors
         class SpecificException(Exception):
@@ -835,29 +812,6 @@ class CircuitBreakerRedisConcurrencyTestCase(unittest.TestCase):
         self._mock_function(self.breaker, _inc_counter)
         self._start_threads(trigger_error, 3)
         self.assertEqual(1500, self.breaker.fail_counter)
-
-    def test_success_thread_safety(self):
-        """CircuitBreaker: it should compute a successful call atomically
-        to avoid race conditions.
-        """
-        @self.breaker
-        def suc(): return True
-
-        def trigger_success():
-            for n in range(500):
-                suc()
-
-        class SuccessListener(CircuitBreakerListener):
-            def success(self, cb):
-                c = 0
-                if hasattr(cb, '_success_counter'):
-                    c = cb._success_counter
-                sleep(0.00005)
-                cb._success_counter = c + 1
-
-        self.breaker.add_listener(SuccessListener())
-        self._start_threads(trigger_success, 3)
-        self.assertEqual(1500, self.breaker._success_counter)
 
     def test_half_open_thread_safety(self):
         """CircuitBreaker: it should allow only one trial call when the
@@ -916,7 +870,7 @@ class CircuitBreakerRedisConcurrencyTestCase(unittest.TestCase):
         self.breaker.add_listener(SleepListener())
         num_threads = 3
         self._start_threads(trigger_error, num_threads)
-        self.assertTrue(self.breaker.fail_counter < self.breaker.fail_max + num_threads)
+        self.assertLess(self.breaker.fail_counter, self.breaker.fail_max + num_threads)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Please note that I don't except this to be accepted, as it changes the concurrency guarantees around the execution of the wrapped method substantially, which could break all sorts of things for current users. But I did think it might be of interest to people using this library under workloads similar to our own, and hence thought I should suggest the change at the least.

This PR removes the locking around the wrapped method call, instead making the `CircuitMemoryStorage` thread-safe, and added another lock to ensure that the counter changes and failure/success behaviour are atomic. This leads to two major consequences - firstly, there's now no expectation of exclusive execution in the wrapped method; and secondly, listener calls may likewise now be concurrent.

Why this madness, you may ask? Our use case is wrapping IO heavy tasks (proxying HTTP calls for assets, in particular) and hence the coarse-but-safe locking behaviour around the wrapped method leads to a major performance impact on our servers. In this case we're very happy to allow looser guarantees to substantially increase throughput.

Finally, thanks very much for all of your work on this library - it's made our lives a lot easier, and is much appreciated!