### PR TITLE
Allow concurrent execution of wrapped method

### DIFF
--- a/src/pybreaker.py
+++ b/src/pybreaker.py
@@ -144,8 +144,9 @@ class CircuitBreaker(object):
         Set cached state and notify listeners of newly cached state.
         """
         with self._lock:
-            self._state = self._create_new_state(
-                state_str, prev_state=self._state, notify=True)
+            if self._state.name != state_str:
+                self._state = self._create_new_state(
+                    state_str, prev_state=self._state, notify=True)
 
     @property
     def current_state(self):

--- a/src/pybreaker.py
+++ b/src/pybreaker.py
@@ -145,6 +145,9 @@ class CircuitBreaker(object):
         """
         with self._lock:
             if self._state.name != state_str:
+                self._state_storage.state = state_str
+                if state_str == STATE_OPEN:
+                    self._state_storage.opened_at = datetime.utcnow()
                 self._state = self._create_new_state(
                     state_str, prev_state=self._state, notify=True)
 
@@ -232,9 +235,7 @@ class CircuitBreaker(object):
         Opens the circuit, e.g., the following calls will immediately fail
         until timeout elapses.
         """
-        with self._lock:
-            self._state_storage.opened_at = datetime.utcnow()
-            self.state = self._state_storage.state = STATE_OPEN
+        self.state = STATE_OPEN
 
     def half_open(self):
         """
@@ -242,15 +243,13 @@ class CircuitBreaker(object):
         opens the circuit if the call fails (or closes the circuit if the call
         succeeds).
         """
-        with self._lock:
-            self.state = self._state_storage.state = STATE_HALF_OPEN
+        self.state = STATE_HALF_OPEN
 
     def close(self):
         """
         Closes the circuit, e.g. lets the following calls execute as usual.
         """
-        with self._lock:
-            self.state = self._state_storage.state = STATE_CLOSED
+        self.state = STATE_CLOSED
 
     def __call__(self, *call_args, **call_kwargs):
         """

--- a/src/pybreaker.py
+++ b/src/pybreaker.py
@@ -874,8 +874,10 @@ class CircuitOpenState(CircuitBreakerState):
             error_msg = 'Timeout not elapsed yet, circuit breaker still open'
             raise CircuitBreakerError(error_msg)
         else:
-            self._breaker.half_open()
-            return self._breaker.call(func, *args, **kwargs)
+            with self._breaker._lock:
+                if self._breaker.current_state == STATE_OPEN:
+                    self._breaker.half_open()
+                    return self._breaker.call(func, *args, **kwargs)
 
     def call(self, func, *args, **kwargs):
         """

--- a/src/pybreaker.py
+++ b/src/pybreaker.py
@@ -688,7 +688,10 @@ class CircuitBreakerState(object):
                 self._breaker._inc_counter()
                 self.on_failure(exc)
             for listener in self._breaker.listeners:
-                listener.failure(self._breaker, exc)
+                try:
+                    listener.failure(self._breaker, exc)
+                except:
+                    pass
         else:
             self._handle_success()
 
@@ -703,7 +706,10 @@ class CircuitBreakerState(object):
             self._breaker._state_storage.reset_counter()
             self.on_success()
         for listener in self._breaker.listeners:
-            listener.success(self._breaker)
+            try:
+                listener.success(self._breaker)
+            except:
+                pass
 
     def call(self, func, *args, **kwargs):
         """
@@ -714,7 +720,10 @@ class CircuitBreakerState(object):
 
         self.before_call(func, *args, **kwargs)
         for listener in self._breaker.listeners:
-            listener.before_call(self._breaker, func, *args, **kwargs)
+            try:
+                listener.before_call(self._breaker, func, *args, **kwargs)
+            except:
+                pass
 
         try:
             ret = func(*args, **kwargs)
@@ -740,7 +749,10 @@ class CircuitBreakerState(object):
 
             self.before_call(func, *args, **kwargs)
             for listener in self._breaker.listeners:
-                listener.before_call(self._breaker, func, *args, **kwargs)
+                try:
+                    listener.before_call(self._breaker, func, *args, **kwargs)
+                except:
+                    pass
 
             try:
                 ret = yield func(*args, **kwargs)
@@ -811,7 +823,10 @@ class CircuitClosedState(CircuitBreakerState):
             # storage).
             self._breaker._state_storage.reset_counter()
             for listener in self._breaker.listeners:
-                listener.state_change(self._breaker, prev_state, self)
+                try:
+                    listener.state_change(self._breaker, prev_state, self)
+                except:
+                    pass
 
     def on_failure(self, exc):
         """
@@ -842,7 +857,10 @@ class CircuitOpenState(CircuitBreakerState):
         super(CircuitOpenState, self).__init__(cb, STATE_OPEN)
         if notify:
             for listener in self._breaker.listeners:
-                listener.state_change(self._breaker, prev_state, self)
+                try:
+                    listener.state_change(self._breaker, prev_state, self)
+                except:
+                    pass
 
     def before_call(self, func, *args, **kwargs):
         """
@@ -884,7 +902,10 @@ class CircuitHalfOpenState(CircuitBreakerState):
         super(CircuitHalfOpenState, self).__init__(cb, STATE_HALF_OPEN)
         if notify:
             for listener in self._breaker._listeners:
-                listener.state_change(self._breaker, prev_state, self)
+                try:
+                    listener.state_change(self._breaker, prev_state, self)
+                except:
+                    pass
 
     def on_failure(self, exc):
         """


### PR DESCRIPTION
This is a revised version of #40.

Please note that I don't except this to be accepted, as it changes the concurrency guarantees around the execution of the wrapped method substantially, which could break all sorts of things for current users. But I did think it might be of interest to people using this library under workloads similar to our own, and hence thought I should suggest the change at the least.

This PR removes the locking around the wrapped method call, instead making the CircuitMemoryStorage thread-safe, and added another lock to ensure that the counter changes and failure/success behaviour are atomic. This leads to two major consequences - firstly, there's now no expectation of exclusive execution in the wrapped method; and secondly, listener calls may likewise now be concurrent.

Why this madness, you may ask? Our use case is wrapping IO heavy tasks (proxying HTTP calls for assets, in particular) and hence the coarse-but-safe locking behaviour around the wrapped method leads to a major performance impact on our servers. In this case we're very happy to allow looser guarantees to substantially increase throughput.

I've also added try/except around listener method invocations, as previously a badly behaved listener could affect the flow of the circuit breaker.

Finally, thanks very much for all of your work on this library - it's made our lives a lot easier, and is much appreciated!