### PR TITLE
Add .gitignore entries for VirtualEnv/VSCode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,6 @@ dist/
 
 # Visual Studio Code
 /.vscode/
+
+# VirtualEnv
+/venv/

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@ dist/
 .idea
 .ropeproject/
 *.iml
+
+# Visual Studio Code
+/.vscode/


### PR DESCRIPTION
This merely adds `.gitignore` entires for [VirtualEnv](https://virtualenv.pypa.io/en/stable/) and [Visual Studio Code](https://code.visualstudio.com).