### PR TITLE
Replace raise with return per PEP 479 recommendations

### DIFF
--- a/src/pybreaker.py
+++ b/src/pybreaker.py
@@ -740,7 +740,7 @@ class CircuitBreakerState(object):
                 value = yield wrapped_generator.send(value)
         except StopIteration:
             self._handle_success()
-            raise
+            return
         except BaseException as e:
             self._handle_error(e)
 


### PR DESCRIPTION
According to PEP 479 documentation (https://www.python.org/dev/peps/pep-0479/#examples-of-breakage), when `StopIteration` occurs, the generator should end with a `return` statement instead of a `raise`.

See the following example from PEP 479:

> More complicated iteration patterns will need explicit try/except constructs. For example, a hypothetical parser like this:
```
def parser(f):
    while True:
        data = next(f)
        while True:
            line = next(f)
            if line == "- end -": break
            data += line
        yield data
```
> would need to be rewritten as:
```
def parser(f):
    while True:
        try:
            data = next(f)
            while True:
                line = next(f)
                if line == "- end -": break
                data += line
            yield data
        except StopIteration:
            return
```