### PR TITLE
Replace pytest.fail with TestCase.fail to minimize dependency

### DIFF
--- a/src/tests.py
+++ b/src/tests.py
@@ -6,7 +6,6 @@ from datetime import datetime
 from time import sleep
 
 import mock
-from pytest import fail
 from tornado import gen
 from tornado import testing
 
@@ -77,7 +76,7 @@ class CircuitBreakerStorageBasedTestCase(object):
         # Circuit should open
         try:
             self.breaker.call(func)
-            fail('CircuitBreakerError should throw')
+            self.fail('CircuitBreakerError should throw')
         except CircuitBreakerError as e:
             import traceback
             self.assertIn('NotImplementedError', traceback.format_exc())


### PR DESCRIPTION
Previously, the tests were importing `pytest` and using it for a `fail` call.
This causes issues when running the repository from scratch, because setup.py doesn't include a pytest dependency. 

The alternative to this approach would be adding the dependency, but since it's only used in one place I assumed you'd rather keep the codebase minimal.

Tested by running `python setup.py test` in a fresh virtualenv before and after.