### PR TITLE
Adding settings to allow passing THROW_NEW_ERROR_ON_TRIP

### DIFF
--- a/src/pybreaker.py
+++ b/src/pybreaker.py
@@ -52,7 +52,7 @@ class CircuitBreaker(object):
     """
 
     def __init__(self, fail_max=5, reset_timeout=60, exclude=None,
-                 listeners=None, state_storage=None, name=None):
+                 listeners=None, state_storage=None, name=None, settings=None):
         """
         Creates a new circuit breaker with the given parameters.
         """
@@ -66,6 +66,8 @@ class CircuitBreaker(object):
         self._excluded_exceptions = list(exclude or [])
         self._listeners = list(listeners or [])
         self._name = name
+
+        self._settings = settings or {}
 
     @property
     def fail_counter(self):
@@ -235,6 +237,8 @@ class CircuitBreaker(object):
         with self._lock:
             self._state_storage.opened_at = datetime.utcnow()
             self.state = self._state_storage.state = STATE_OPEN
+
+            return self._settings.get("THROW_NEW_ERROR_ON_TRIP", True)
 
     def half_open(self):
         """
@@ -800,10 +804,13 @@ class CircuitClosedState(CircuitBreakerState):
         threshold is reached.
         """
         if self._breaker._state_storage.counter >= self._breaker.fail_max:
-            self._breaker.open()
+            throw_new_error = self._breaker.open()
 
-            error_msg = 'Failures threshold reached, circuit breaker opened'
-            six.reraise(CircuitBreakerError, CircuitBreakerError(error_msg), sys.exc_info()[2])
+            if throw_new_error:
+                error_msg = 'Failures threshold reached, circuit breaker opened'
+                six.reraise(CircuitBreakerError, CircuitBreakerError(error_msg), sys.exc_info()[2])
+            else:
+                raise exc
 
 
 class CircuitOpenState(CircuitBreakerState):
@@ -871,9 +878,13 @@ class CircuitHalfOpenState(CircuitBreakerState):
         """
         Opens the circuit breaker.
         """
-        self._breaker.open()
-        error_msg = 'Trial call failed, circuit breaker opened'
-        six.reraise(CircuitBreakerError, CircuitBreakerError(error_msg), sys.exc_info()[2])
+        throw_new_error = self._breaker.open()
+
+        if throw_new_error:
+            error_msg = 'Trial call failed, circuit breaker opened'
+            six.reraise(CircuitBreakerError, CircuitBreakerError(error_msg), sys.exc_info()[2])
+        else:
+            raise exc
 
     def on_success(self):
         """

--- a/src/pybreaker.py
+++ b/src/pybreaker.py
@@ -52,7 +52,7 @@ class CircuitBreaker(object):
     """
 
     def __init__(self, fail_max=5, reset_timeout=60, exclude=None,
-                 listeners=None, state_storage=None, name=None, settings=None):
+                 listeners=None, state_storage=None, name=None, throw_new_error_on_trip=True):
         """
         Creates a new circuit breaker with the given parameters.
         """
@@ -67,7 +67,7 @@ class CircuitBreaker(object):
         self._listeners = list(listeners or [])
         self._name = name
 
-        self._settings = settings or {}
+        self._throw_new_error_on_trip = throw_new_error_on_trip
 
     @property
     def fail_counter(self):
@@ -238,7 +238,7 @@ class CircuitBreaker(object):
             self._state_storage.opened_at = datetime.utcnow()
             self.state = self._state_storage.state = STATE_OPEN
 
-            return self._settings.get("THROW_NEW_ERROR_ON_TRIP", True)
+            return self._throw_new_error_on_trip
 
     def half_open(self):
         """

--- a/src/tests.py
+++ b/src/tests.py
@@ -50,10 +50,42 @@ class CircuitBreakerStorageBasedTestCase(object):
         self.assertEqual(0, self.breaker.fail_counter)
         self.assertEqual('closed', self.breaker.current_state)
 
-    def test_several_failed_calls(self):
+    def test_several_failed_calls_setting_absent(self):
         """CircuitBreaker: it should open the circuit after many failures.
         """
         self.breaker = CircuitBreaker(fail_max=3, **self.breaker_kwargs)
+        def func(): raise NotImplementedError()
+
+        self.assertRaises(NotImplementedError, self.breaker.call, func)
+        self.assertRaises(NotImplementedError, self.breaker.call, func)
+
+        # Circuit should open
+        self.assertRaises(CircuitBreakerError, self.breaker.call, func)
+        self.assertEqual(3, self.breaker.fail_counter)
+        self.assertEqual('open', self.breaker.current_state)
+
+    def test_throw_new_error_on_trip_setting_false(self):
+        """CircuitBreaker: it should throw the original exception"""
+        self.breaker = CircuitBreaker(fail_max=3, **self.breaker_kwargs, settings={"THROW_NEW_ERROR_ON_TRIP": False})
+        def func(): raise NotImplementedError()
+
+        self.assertRaises(NotImplementedError, self.breaker.call, func)
+        self.assertRaises(NotImplementedError, self.breaker.call, func)
+        self.assertRaises(NotImplementedError, self.breaker.call, func)
+
+        # Circuit should be open
+        self.assertEqual(3, self.breaker.fail_counter)
+        self.assertEqual('open', self.breaker.current_state)
+
+        # Circuit should still be open and break 
+        self.assertRaises(CircuitBreakerError, self.breaker.call, func)
+        self.assertEqual(3, self.breaker.fail_counter)
+        self.assertEqual('open', self.breaker.current_state)
+
+
+    def test_throw_new_error_on_trip_setting_true(self):
+        """CircuitBreaker: it should throw a CircuitBreakerError exception"""
+        self.breaker = CircuitBreaker(fail_max=3, **self.breaker_kwargs, settings={"THROW_NEW_ERROR_ON_TRIP": True})
         def func(): raise NotImplementedError()
 
         self.assertRaises(NotImplementedError, self.breaker.call, func)

--- a/src/tests.py
+++ b/src/tests.py
@@ -64,9 +64,9 @@ class CircuitBreakerStorageBasedTestCase(object):
         self.assertEqual(3, self.breaker.fail_counter)
         self.assertEqual('open', self.breaker.current_state)
 
-    def test_throw_new_error_on_trip_setting_false(self):
+    def test_throw_new_error_on_trip_false(self):
         """CircuitBreaker: it should throw the original exception"""
-        self.breaker = CircuitBreaker(fail_max=3, **self.breaker_kwargs, settings={"THROW_NEW_ERROR_ON_TRIP": False})
+        self.breaker = CircuitBreaker(fail_max=3, **self.breaker_kwargs, throw_new_error_on_trip=False)
         def func(): raise NotImplementedError()
 
         self.assertRaises(NotImplementedError, self.breaker.call, func)
@@ -83,9 +83,9 @@ class CircuitBreakerStorageBasedTestCase(object):
         self.assertEqual('open', self.breaker.current_state)
 
 
-    def test_throw_new_error_on_trip_setting_true(self):
+    def test_throw_new_error_on_trip_true(self):
         """CircuitBreaker: it should throw a CircuitBreakerError exception"""
-        self.breaker = CircuitBreaker(fail_max=3, **self.breaker_kwargs, settings={"THROW_NEW_ERROR_ON_TRIP": True})
+        self.breaker = CircuitBreaker(fail_max=3, **self.breaker_kwargs, throw_new_error_on_trip=True)
         def func(): raise NotImplementedError()
 
         self.assertRaises(NotImplementedError, self.breaker.call, func)


### PR DESCRIPTION
Fix for https://github.com/danielfm/pybreaker/issues/60

The setting lets you alter the default behaviour of throwing a new CircuitBreakerError every time the circuit opens. By setting THROW_NEW_ERROR_ON_TRIP to False, the original exception will be preserved when the circuit breaker opens

The default value for this setting is True, which mimics the current behaviour of the library. 