### PR TITLE
Add `python_requires` on setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,7 @@ setup(
     py_modules=['pybreaker'],
     include_package_data=True,
     zip_safe=False,
+    python_requires=">=3.6",
     test_suite='tests',
     tests_require=[
         'mock',


### PR DESCRIPTION
This makes PR avoids issues with `pip` package resolution.

Consider that support for Python 3.6 is removed, when `pybreaker` is installed on Python 3.6, if we don't add this, it will fail, as the latest version will be installed.

See more on https://packaging.python.org/en/latest/guides/distributing-packages-using-setuptools/#python-requires.