### PR TITLE
Enable pipeline on pull requests

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: [main]
   pull_request:
+    branches: [main]
 
 jobs:
   test:


### PR DESCRIPTION
This enables the pipeline on PRs. Without specifying the target branch on that line, this PR will not trigger it.