### PR TITLE
Drop Python 3.6 support

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
     steps:
       - uses: actions/checkout@v3
 

--- a/README.rst
+++ b/README.rst
@@ -27,7 +27,7 @@ Features
 Requirements
 ------------
 
-* `Python`_ 3.6+
+* `Python`_ 3.7+
 
 
 Installation

--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,11 @@ setup(
         'License :: OSI Approved :: BSD License',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11',
         'Topic :: Software Development :: Libraries',
     ],
     platforms=[
@@ -28,7 +33,7 @@ setup(
     py_modules=['pybreaker'],
     include_package_data=True,
     zip_safe=False,
-    python_requires=">=3.6",
+    python_requires=">=3.7",
     test_suite='tests',
     tests_require=[
         'mock',

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,6 @@ setup(
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
-        'Programming Language :: Python :: 3.11',
         'Topic :: Software Development :: Libraries',
     ],
     platforms=[


### PR DESCRIPTION
Python 3.6 has reached EOL last year: https://endoflife.date/python