### PR TITLE
Fix `state` parameter type hint on `CircuitRedisStorage.__init__`

### DIFF
--- a/src/pybreaker.py
+++ b/src/pybreaker.py
@@ -512,7 +512,7 @@ class CircuitRedisStorage(CircuitBreakerStorage):
 
     def __init__(
         self,
-        state: CircuitBreakerState,
+        state: str,
         redis_object: Redis,
         namespace: str | None = None,
         fallback_circuit_state: str = STATE_CLOSED,


### PR DESCRIPTION
Just find out... 😰 