### PR TITLE
Add calling() method to CircuitBreaker, returning a context manager

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,7 +1,7 @@
 Changelog
 =========
 
-Version 1.1.0 (December 27, 2023)
+Version 1.1.0 (January 09, 2024)
 
 * Added calling() method to CircuitBreaker, returning a context manager (Thanks @martijnthe)
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,10 @@
 Changelog
 =========
 
+Version 1.1.0 (December 27, 2023)
+
+* Added calling() method to CircuitBreaker, returning a context manager (Thanks @martijnthe)
+
 Version 1.0.3 (December 22, 2023)
 
 * Added py.typed file (Thanks @martijnthe)

--- a/README.rst
+++ b/README.rst
@@ -182,6 +182,16 @@ Or if you don't want to use the decorator syntax:
     # Will trigger the circuit breaker
     updated_customer = db_breaker.call(update_customer, my_customer)
 
+Or use it as a context manager and a `with` statement:
+
+.. code:: python
+
+    # Will trigger the circuit breaker
+    with db_breaker.calling():
+        # Do stuff here...
+        pass
+
+
 
 According to the default parameters, the circuit breaker ``db_breaker`` will
 automatically open the circuit after 5 consecutive failures in

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name="pybreaker",
-    version="1.0.3",
+    version="1.1.0",
     description="Python implementation of the Circuit Breaker pattern",
     long_description=open("README.rst", "r").read(),
     keywords=["design", "pattern", "circuit", "breaker", "integration"],

--- a/src/pybreaker/__init__.py
+++ b/src/pybreaker/__init__.py
@@ -8,6 +8,7 @@ book at https://pragprog.com/titles/mnee2/release-it-second-edition/
 from __future__ import annotations
 
 import calendar
+import contextlib
 import logging
 import sys
 import threading
@@ -27,6 +28,7 @@ from typing import (
     Union,
     cast,
     overload,
+    Iterable,
 )
 
 if sys.version_info >= (3, 8):
@@ -259,6 +261,19 @@ class CircuitBreaker:
         """
         with self._lock:
             return self.state.call(func, *args, **kwargs)
+
+    @contextlib.contextmanager
+    def calling(self) -> Iterable[None]:
+        """
+        Returns a context manager, enabling the circuit breaker to be used with a
+        `with` statement. The block of code inside the `with` statement will be
+        executed according to the rules implemented by the current state of this
+        circuit breaker.
+        """
+        def _wrapper() -> None:
+            yield
+
+        yield from self.call(_wrapper)
 
     def call_async(self, func, *args, **kwargs):  # type: ignore[no-untyped-def]
         """


### PR DESCRIPTION
  ### Summary

This adds a new `calling()` method to `CircuitBreaker`. This method returns a context manager, enabling the circuit breaker to be used with a `with` statement. The block of code inside the `with` statement will be executed according to the rules implemented by the current state of the circuit breaker.

Fixes: https://github.com/danielfm/pybreaker/issues/85

Example usage:
```
    db_breaker = CircuitBreaker()

    # Will trigger the circuit breaker
    with db_breaker.calling():
        # Do stuff here...
        pass

```

  ### Implementation Details

Initially, I attempted to make the `CircuitBreaker` itself a context manager, by implementing `__enter__` and `__exit__` in the class itself, but this required an amount of refactoring that I was not comfortable with. Therefore, I opted to implement this on top of the existing `call` method.

As for the naming of the new method, I took inspiration from [PEP 0343](https://peps.python.org/pep-0343/#examples), where the authors suggested using paste tense ("-ed") or progressive tense ("-ing"). Even though the new method itself isn't calling the `with` block itself, conceptually, it can be thought of doing so.

  ### Test Plan

Added a test case that exercises the new API.