### PR TITLE
Convert datetime.utcnow -> datetime.now(UTC)

### DIFF
--- a/src/pybreaker/__init__.py
+++ b/src/pybreaker/__init__.py
@@ -15,7 +15,7 @@ import threading
 import time
 import types
 from abc import abstractmethod
-from datetime import datetime, timedelta, UTC
+from datetime import UTC, datetime, timedelta
 from functools import wraps
 from typing import (
     Any,

--- a/src/pybreaker/__init__.py
+++ b/src/pybreaker/__init__.py
@@ -15,7 +15,7 @@ import threading
 import time
 import types
 from abc import abstractmethod
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, UTC
 from functools import wraps
 from typing import (
     Any,
@@ -254,7 +254,7 @@ class CircuitBreaker:
     def open(self) -> bool:
         """Open the circuit, e.g., the following calls will immediately fail until timeout elapses."""
         with self._lock:
-            self._state_storage.opened_at = datetime.utcnow()
+            self._state_storage.opened_at = datetime.now(UTC)
             self.state = self._state_storage.state = STATE_OPEN  # type: ignore[assignment]
 
             return self._throw_new_error_on_trip
@@ -763,7 +763,7 @@ class CircuitOpenState(CircuitBreakerState):
         """
         timeout = timedelta(seconds=self._breaker.reset_timeout)
         opened_at = self._breaker._state_storage.opened_at
-        if opened_at and datetime.utcnow() < opened_at + timeout:
+        if opened_at and datetime.now(UTC) < opened_at + timeout:
             error_msg = "Timeout not elapsed yet, circuit breaker still open"
             raise CircuitBreakerError(error_msg)
         self._breaker.half_open()


### PR DESCRIPTION
Removes deprecation warning and makes a timezone (UTC) aware datetime object.

<img width="1223" alt="Screenshot 2024-06-11 at 14 45 30" src="https://github.com/danielfm/pybreaker/assets/1122069/27f6bc27-cd20-4f90-93b5-68ad7c6578ae">

```
  /Users/psi29a/Workspace/backend/venv/lib/python3.12/site-packages/pybreaker/__init__.py:257: DeprecationWarning: datetime.datetime.utcnow() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.now(datetime.UTC).
    self._state_storage.opened_at = datetime.utcnow()

  /Users/psi29a/Workspace/backend/venv/lib/python3.12/site-packages/pybreaker/__init__.py:766: DeprecationWarning: datetime.datetime.utcnow() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.now(datetime.UTC).
    if opened_at and datetime.utcnow() < opened_at + timeout:
    ```