### PR TITLE
Convert datetime.utcnow -> datetime.now(UTC)

### DIFF
--- a/src/pybreaker/__init__.py
+++ b/src/pybreaker/__init__.py
@@ -15,7 +15,7 @@ import threading
 import time
 import types
 from abc import abstractmethod
-from datetime import datetime, timedelta, UTC
+from datetime import UTC, datetime, timedelta
 from functools import wraps
 from typing import (
     Any,

--- a/src/pybreaker/__init__.py
+++ b/src/pybreaker/__init__.py
@@ -520,7 +520,7 @@ class CircuitRedisStorage(CircuitBreakerStorage):
         try:
             timestamp = self._redis.get(self._namespace("opened_at"))
             if timestamp:
-                return datetime(*time.gmtime(int(timestamp))[:6])
+                return datetime(*time.gmtime(int(timestamp))[:6], tzinfo=UTC)
         except RedisError:
             self.logger.exception("RedisError")
         return None

--- a/src/pybreaker/__init__.py
+++ b/src/pybreaker/__init__.py
@@ -31,10 +31,11 @@ from typing import (
     overload,
 )
 
+# For compatibility with Python 3.10 and earlier.
+# Otherwise, `from datetime import UTC` would suffice.
 try:
-    from datetime import UTC
+    from datetime import UTC  # type: ignore[attr-defined]
 except ImportError:
-    # For compatibility with Python 3.10 and earlier
     from datetime import timezone
 
     UTC = timezone.utc

--- a/src/pybreaker/__init__.py
+++ b/src/pybreaker/__init__.py
@@ -15,7 +15,7 @@ import threading
 import time
 import types
 from abc import abstractmethod
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, UTC
 from functools import wraps
 from typing import (
     Any,
@@ -254,7 +254,7 @@ class CircuitBreaker:
     def open(self) -> bool:
         """Open the circuit, e.g., the following calls will immediately fail until timeout elapses."""
         with self._lock:
-            self._state_storage.opened_at = datetime.utcnow()
+            self._state_storage.opened_at = datetime.now(UTC)
             self.state = self._state_storage.state = STATE_OPEN  # type: ignore[assignment]
 
             return self._throw_new_error_on_trip
@@ -763,7 +763,7 @@ class CircuitOpenState(CircuitBreakerState):
         """
         timeout = timedelta(seconds=self._breaker.reset_timeout)
         opened_at = self._breaker._state_storage.opened_at
-        if opened_at and datetime.utcnow() < opened_at + timeout:
+        if opened_at and datetime.now(UTC) < opened_at + timeout:
             error_msg = "Timeout not elapsed yet, circuit breaker still open"
             raise CircuitBreakerError(error_msg)
         self._breaker.half_open()

--- a/src/pybreaker/__init__.py
+++ b/src/pybreaker/__init__.py
@@ -15,7 +15,7 @@ import threading
 import time
 import types
 from abc import abstractmethod
-from datetime import UTC, datetime, timedelta
+from datetime import datetime, timedelta
 from functools import wraps
 from typing import (
     Any,
@@ -30,6 +30,14 @@ from typing import (
     cast,
     overload,
 )
+
+try:
+    from datetime import UTC
+except ImportError:
+    # For compatibility with Python 3.10 and earlier
+    from datetime import timezone
+
+    UTC = timezone.utc
 
 try:
     from tornado import gen


### PR DESCRIPTION
Supersedes danielfm/pybreaker#92, which switched to UTC-based datetimes (aware), but didn't extend that adjustment to reading the timestamp from Redis.