### PR TITLE
Add success_threshold parameter 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ dist/
 
 # VirtualEnv
 /venv/
+*~


### PR DESCRIPTION
- Add success_threshold parameter to CircuitBreaker constructor (default: 1 for backward compatibility)
- Add success_counter property to track consecutive successes in half-open state
- Update CircuitBreakerStorage interface to support success counter operations
- Implement success counter in CircuitMemoryStorage and CircuitRedisStorage
- Modify CircuitHalfOpenState to increment success counter and only close when threshold is reached
- Reset success counter when circuit opens or closes
- Add tests for success threshold functionality
- Fix test_namespace to expect 3 Redis keys (fail_counter, success_counter, state)