### PR TITLE
Add CircuitBreaker.acall for native asyncio

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,4 +23,5 @@ dist/
 
 # VirtualEnv
 /venv/
+.venv-ci/
 *~

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,10 @@
 Changelog
 =========
 
+Version 1.5.0 (unreleased)
+
+* Add ``CircuitBreaker.acall`` for native asyncio callables.
+
 Version 1.4.0 (July 6, 2025)
 
 * Add success_threshold parameter (Thanks @sideshowbandana)

--- a/src/pybreaker/__init__.py
+++ b/src/pybreaker/__init__.py
@@ -7,8 +7,10 @@ book at https://pragprog.com/titles/mnee2/release-it-second-edition/
 
 from __future__ import annotations
 
+import asyncio
 import calendar
 import contextlib
+import inspect
 import logging
 import sys
 import threading
@@ -113,6 +115,21 @@ class CircuitBreaker:
         self._name = name
 
         self._throw_new_error_on_trip = throw_new_error_on_trip
+        self._async_lock: asyncio.Lock | None = None
+
+    def _ensure_async_lock(self) -> asyncio.Lock:
+        """Lazily create the asyncio lock used by `acall` (thread-safe).
+
+        The lock is created once per breaker. On Python 3.10+ this is safe across
+        sequential ``asyncio.run()`` calls (new event loop each time). On 3.9,
+        reuse across different loops is theoretically fragile; prefer one loop
+        per long-lived breaker until 3.9 support is dropped.
+        """
+        if self._async_lock is None:
+            with self._lock:
+                if self._async_lock is None:
+                    self._async_lock = asyncio.Lock()
+        return self._async_lock
 
     @property
     def fail_counter(self) -> int:
@@ -262,6 +279,21 @@ class CircuitBreaker:
             yield
 
         yield from self.call(_wrapper)
+
+    async def acall(self, func: Callable[..., Any], *args: Any, **kwargs: Any) -> Any:
+        """Call async (or awaitable-returning) ``func`` under the same state rules as
+        :meth:`call`, using :class:`asyncio.Lock` for mutual exclusion between
+        concurrent ``acall`` invocations.
+
+        ``func`` must be an ``async def`` or return an awaitable when invoked.
+        Sync generators, async generators, and Tornado coroutines are not
+        supported; use :meth:`call` / :meth:`call_async` instead.
+
+        Mixing :meth:`call` and ``acall`` on one instance is not guaranteed to
+        serialize; prefer one style per breaker where possible.
+        """
+        async with self._ensure_async_lock():
+            return await self.state.acall(func, *args, **kwargs)
 
     def call_async(self, func, *args, **kwargs):  # type: ignore[no-untyped-def]
         """Call async `func` with the given `args` and `kwargs` according to the rules
@@ -727,6 +759,30 @@ class CircuitBreakerState:
             self._handle_success()
         return ret
 
+    async def acall(self, func: Callable[..., Any], *args: Any, **kwargs: Any) -> Any:
+        """Async counterpart to :meth:`call` for ``async def`` and awaitable-returning callables."""
+        ret: Any = None
+
+        self.before_call(func, *args, **kwargs)
+        for listener in self._breaker.listeners:
+            listener.before_call(self._breaker, func, *args, **kwargs)
+
+        try:
+            ret = func(*args, **kwargs)
+            if inspect.isawaitable(ret):
+                ret = await ret
+        except BaseException as e:
+            self._handle_error(e)
+        else:
+            if isinstance(ret, types.GeneratorType):
+                msg = "acall does not support synchronous generators; use call() instead"
+                raise TypeError(msg)
+            if inspect.isasyncgen(ret):
+                msg = "acall does not support async generators; use an async function that returns a value"
+                raise TypeError(msg)
+            self._handle_success()
+        return ret
+
     def call_async(self, func, *args: Any, **kwargs: Any):  # type: ignore[no-untyped-def]
         """Call async `func` with the given `args` and `kwargs`, and updates the
         circuit breaker state according to the result.
@@ -856,6 +912,16 @@ class CircuitOpenState(CircuitBreakerState):
         the results from the call performed after the state is switch to half-open.
         """
         return self.before_call(func, *args, **kwargs)
+
+    async def acall(self, func: Callable[..., Any], *args: Any, **kwargs: Any) -> Any:
+        """After timeout, move to half-open and run the guarded operation via async path."""
+        timeout = timedelta(seconds=self._breaker.reset_timeout)
+        opened_at = self._breaker._state_storage.opened_at
+        if opened_at and datetime.now(UTC) < opened_at + timeout:
+            error_msg = "Timeout not elapsed yet, circuit breaker still open"
+            raise CircuitBreakerError(error_msg)
+        self._breaker.half_open()
+        return await self._breaker.state.acall(func, *args, **kwargs)
 
 
 class CircuitHalfOpenState(CircuitBreakerState):

--- a/tests/pybreaker_test.py
+++ b/tests/pybreaker_test.py
@@ -1,3 +1,4 @@
+import asyncio
 import unittest
 from contextlib import contextmanager
 from datetime import datetime
@@ -1350,6 +1351,231 @@ class CircuitBreakerContextManagerTestCase(unittest.TestCase):
         mock_fn.assert_called_once()
         assert breaker.fail_counter == 0
         assert breaker.current_state == "closed"
+
+
+class CircuitBreakerAsyncioTestCase(unittest.TestCase):
+    """Tests for native asyncio :meth:`CircuitBreaker.acall` (PR 1: core API only)."""
+
+    def test_acall_success_closed(self):
+        breaker = CircuitBreaker()
+
+        async def ok():
+            return 42
+
+        assert asyncio.run(breaker.acall(ok)) == 42
+        assert breaker.fail_counter == 0
+        assert breaker.current_state == "closed"
+
+    def test_acall_with_args(self):
+        breaker = CircuitBreaker()
+
+        async def add(a, b):
+            return a + b
+
+        assert asyncio.run(breaker.acall(add, 40, 2)) == 42
+
+    def test_acall_with_kwargs(self):
+        breaker = CircuitBreaker()
+
+        async def merge(**kwargs):
+            return kwargs
+
+        assert asyncio.run(breaker.acall(merge, a=1, b=2)) == {"a": 1, "b": 2}
+
+    def test_acall_listener_callbacks(self):
+        breaker = CircuitBreaker()
+
+        class RecordingListener(CircuitBreakerListener):
+            def __init__(self) -> None:
+                self.before = 0
+                self.successes = 0
+                self.failures = 0
+
+            def before_call(self, cb, func, *args, **kwargs):
+                self.before += 1
+
+            def success(self, cb):
+                self.successes += 1
+
+            def failure(self, cb, exc):
+                self.failures += 1
+
+        listener = RecordingListener()
+        breaker.add_listener(listener)
+
+        async def ok():
+            return 1
+
+        async def bad():
+            raise ValueError("x")
+
+        async def run():
+            assert await breaker.acall(ok) == 1
+            with pytest.raises(ValueError):
+                await breaker.acall(bad)
+
+        asyncio.run(run())
+        assert listener.before == 2
+        assert listener.successes == 1
+        assert listener.failures == 1
+
+    def test_acall_failures_open_circuit(self):
+        breaker = CircuitBreaker(fail_max=3)
+
+        async def err():
+            raise NotImplementedError
+
+        async def run_fails():
+            with pytest.raises(NotImplementedError):
+                await breaker.acall(err)
+            with pytest.raises(NotImplementedError):
+                await breaker.acall(err)
+            with pytest.raises(CircuitBreakerError):
+                await breaker.acall(err)
+
+        asyncio.run(run_fails())
+        assert breaker.fail_counter == 3
+        assert breaker.current_state == "open"
+
+    def test_acall_throw_new_error_on_trip_false(self):
+        breaker = CircuitBreaker(fail_max=3, throw_new_error_on_trip=False)
+
+        async def err():
+            raise NotImplementedError
+
+        async def run_all():
+            with pytest.raises(NotImplementedError):
+                await breaker.acall(err)
+            with pytest.raises(NotImplementedError):
+                await breaker.acall(err)
+            with pytest.raises(NotImplementedError):
+                await breaker.acall(err)
+
+        asyncio.run(run_all())
+        assert breaker.fail_counter == 3
+        assert breaker.current_state == "open"
+
+    def test_acall_open_raises_until_timeout(self):
+        # fail_max=1 trips on first failure with CircuitBreakerError by default;
+        # use throw_new_error_on_trip=False so the original error propagates once.
+        breaker = CircuitBreaker(fail_max=1, reset_timeout=60, throw_new_error_on_trip=False)
+
+        async def err():
+            raise RuntimeError("boom")
+
+        async def trip():
+            with pytest.raises(RuntimeError, match="boom"):
+                await breaker.acall(err)
+
+        asyncio.run(trip())
+        assert breaker.current_state == "open"
+
+        async def blocked():
+            with pytest.raises(CircuitBreakerError, match="Timeout not elapsed"):
+                await breaker.acall(err)
+
+        asyncio.run(blocked())
+
+    def test_acall_recovery_after_reset_timeout(self):
+        breaker = CircuitBreaker(fail_max=1, reset_timeout=0.01, throw_new_error_on_trip=False)
+
+        async def err():
+            raise NotImplementedError
+
+        async def ok():
+            return True
+
+        async def run():
+            with pytest.raises(NotImplementedError):
+                await breaker.acall(err)
+            assert breaker.current_state == "open"
+            await asyncio.sleep(0.02)
+            assert await breaker.acall(ok)
+            assert breaker.current_state == "closed"
+            assert breaker.fail_counter == 0
+
+        asyncio.run(run())
+
+    def test_acall_excluded_exceptions(self):
+        breaker = CircuitBreaker(exclude=[LookupError])
+
+        async def err_sys():
+            raise NotImplementedError
+
+        async def err_biz():
+            raise LookupError
+
+        async def run():
+            with pytest.raises(NotImplementedError):
+                await breaker.acall(err_sys)
+            assert breaker.fail_counter == 1
+            with pytest.raises(LookupError):
+                await breaker.acall(err_biz)
+            assert breaker.fail_counter == 0
+
+        asyncio.run(run())
+
+    def test_acall_rejects_sync_generator(self):
+        breaker = CircuitBreaker()
+
+        def gen():
+            yield 1
+
+        async def run():
+            with pytest.raises(TypeError, match="acall does not support"):
+                await breaker.acall(gen)
+
+        asyncio.run(run())
+        assert breaker.fail_counter == 0
+        assert breaker.current_state == "closed"
+
+    def test_acall_rejects_async_generator(self):
+        breaker = CircuitBreaker()
+
+        async def agen():
+            yield 1
+
+        async def run():
+            with pytest.raises(TypeError, match="async generators"):
+                await breaker.acall(agen)
+
+        asyncio.run(run())
+        assert breaker.fail_counter == 0
+        assert breaker.current_state == "closed"
+
+    def test_acall_half_open_failure_raises_circuit_breaker_error(self):
+        """Default throw_new_error_on_trip: half-open trial failure surfaces CircuitBreakerError."""
+        breaker = CircuitBreaker(fail_max=1, reset_timeout=0.01)
+
+        async def err():
+            raise NotImplementedError
+
+        async def run():
+            with pytest.raises(CircuitBreakerError, match="Failures threshold"):
+                await breaker.acall(err)
+            await asyncio.sleep(0.02)
+            with pytest.raises(CircuitBreakerError, match="Trial call failed"):
+                await breaker.acall(err)
+            assert breaker.current_state == "open"
+
+        asyncio.run(run())
+
+    def test_acall_half_open_failure_reopens_with_original_error(self):
+        """With throw_new_error_on_trip=False, half-open trial failure re-raises the call error."""
+        breaker = CircuitBreaker(fail_max=1, reset_timeout=0.01, throw_new_error_on_trip=False)
+
+        async def err():
+            raise NotImplementedError
+
+        async def run():
+            with pytest.raises(NotImplementedError):
+                await breaker.acall(err)
+            await asyncio.sleep(0.02)
+            with pytest.raises(NotImplementedError):
+                await breaker.acall(err)
+            assert breaker.current_state == "open"
+
+        asyncio.run(run())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
- Add asyncio.Lock (lazy, thread-safe) and async acall() on CircuitBreaker
- Implement state.acall with awaitable support; reject sync/async generators
- CircuitOpenState.acall delegates to half-open without re-entering acall
- Tests: CircuitBreakerAsyncioTestCase (stdlib asyncio.run)
- CHANGELOG: unreleased 1.5.0 note; .gitignore .venv-ci/
