### PR TITLE
Add optional open-circuit fallback callable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,4 +23,5 @@ dist/
 
 # VirtualEnv
 /venv/
+.venv-ci/
 *~

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,10 @@
 Changelog
 =========
 
+Version 1.5.0 (unreleased)
+
+* Add ``CircuitBreaker.acall`` for native asyncio callables.
+
 Version 1.4.0 (July 6, 2025)
 
 * Add success_threshold parameter (Thanks @sideshowbandana)

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,6 +4,7 @@ Changelog
 Version 1.5.0 (unreleased)
 
 * Add ``CircuitBreaker.acall`` for native asyncio callables.
+* Document asyncio usage in README; add ``__pybreaker_call_acall`` decorator flag.
 
 Version 1.4.0 (July 6, 2025)
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,6 +5,7 @@ Version 1.5.0 (unreleased)
 
 * Add ``CircuitBreaker.acall`` for native asyncio callables.
 * Document asyncio usage in README; add ``__pybreaker_call_acall`` decorator flag.
+* Add optional ``fallback`` for open-circuit short-circuit (Hystrix-style); supports sync and async for ``acall``.
 
 Version 1.4.0 (July 6, 2025)
 

--- a/README.rst
+++ b/README.rst
@@ -22,6 +22,7 @@ Features
 * Thread-safe
 * Optional redis backing
 * Optional support for asynchronous Tornado calls
+* Optional ``CircuitBreaker.acall`` for asyncio (stdlib)
 
 
 Requirements
@@ -258,6 +259,27 @@ Or if you don't want to use the decorator syntax:
         pass
 
     updated_customer = db_breaker.call_async(async_update, my_customer)
+
+
+Native asyncio (stdlib)
+```````````````````````
+
+For ``async def`` functions, use ``CircuitBreaker.acall`` or the decorator
+with ``__pybreaker_call_acall=True``. This path uses ``asyncio.Lock`` and
+does not require Tornado. Do not mix ``__pybreaker_call_acall`` with
+``__pybreaker_call_async`` on the same decorator.
+
+.. code:: python
+
+    @db_breaker(__pybreaker_call_acall=True)
+    async def async_fetch(url: str) -> bytes:
+        ...
+
+    # or without decorator syntax:
+    async def async_fetch(url: str) -> bytes:
+        ...
+
+    data = await db_breaker.acall(async_fetch, "https://example.com")
 
 
 Excluding Exceptions

--- a/README.rst
+++ b/README.rst
@@ -23,6 +23,7 @@ Features
 * Optional redis backing
 * Optional support for asynchronous Tornado calls
 * Optional ``CircuitBreaker.acall`` for asyncio (stdlib)
+* Optional open-circuit ``fallback`` callable
 
 
 Requirements
@@ -280,6 +281,34 @@ does not require Tornado. Do not mix ``__pybreaker_call_acall`` with
         ...
 
     data = await db_breaker.acall(async_fetch, "https://example.com")
+
+
+Open-circuit fallback (optional)
+````````````````````````````````
+
+If you pass ``fallback`` when creating the breaker, that callable is used when
+the circuit is **open** and the reset timeout has **not** yet elapsed (the
+short-circuit case). It receives the same ``*args`` and ``**kwargs`` as the
+guarded call; the primary function is not executed. This matches the usual
+Hystrix-style behavior. ``throw_new_error_on_trip`` only affects what happens
+when the breaker **trips** after failures; it does not disable the fallback.
+
+.. code:: python
+
+    def stale_cache(*args, **kwargs):
+        return load_from_local_cache(*args, **kwargs)
+
+    db_breaker = CircuitBreaker(
+        fail_max=5,
+        reset_timeout=60,
+        fallback=stale_cache,
+    )
+
+    # When open and still within reset_timeout, returns fallback result instead of
+    # raising ``CircuitBreakerError``.
+
+For ``CircuitBreaker.acall``, an ``async def`` fallback works: if invoking
+``fallback`` returns an awaitable, it is awaited.
 
 
 Excluding Exceptions

--- a/src/pybreaker/__init__.py
+++ b/src/pybreaker/__init__.py
@@ -336,16 +336,32 @@ class CircuitBreaker:
         """Return a wrapper that calls the function `func` according to the rules
         implemented by the current state of this circuit breaker.
 
-        Optionally takes the keyword argument `__pybreaker_call_coroutine`,
-        which will will call `func` as a Tornado co-routine.
+        Optional keyword arguments (mutually exclusive):
+
+        * ``__pybreaker_call_async=True`` — wrap for Tornado (requires tornado).
+        * ``__pybreaker_call_acall=True`` — wrap as an ``async def`` that uses
+          :meth:`acall` (stdlib asyncio).
         """
         call_async = call_kwargs.pop("__pybreaker_call_async", False)
+        call_acall = call_kwargs.pop("__pybreaker_call_acall", False)
+
+        if call_async and call_acall:
+            msg = "Cannot set both __pybreaker_call_async and __pybreaker_call_acall"
+            raise ValueError(msg)
 
         if call_async and not HAS_TORNADO_SUPPORT:
             message = "No module named tornado"
             raise ImportError(message)
 
         def _outer_wrapper(func):  # type: ignore[no-untyped-def]
+            if call_acall:
+
+                @wraps(func)
+                async def _inner_acall(*args, **kwargs):  # type: ignore[no-untyped-def]
+                    return await self.acall(func, *args, **kwargs)
+
+                return _inner_acall
+
             @wraps(func)
             def _inner_wrapper(*args, **kwargs):  # type: ignore[no-untyped-def]
                 if call_async:

--- a/src/pybreaker/__init__.py
+++ b/src/pybreaker/__init__.py
@@ -7,8 +7,10 @@ book at https://pragprog.com/titles/mnee2/release-it-second-edition/
 
 from __future__ import annotations
 
+import asyncio
 import calendar
 import contextlib
+import inspect
 import logging
 import sys
 import threading
@@ -113,6 +115,21 @@ class CircuitBreaker:
         self._name = name
 
         self._throw_new_error_on_trip = throw_new_error_on_trip
+        self._async_lock: asyncio.Lock | None = None
+
+    def _ensure_async_lock(self) -> asyncio.Lock:
+        """Lazily create the asyncio lock used by `acall` (thread-safe).
+
+        The lock is created once per breaker. On Python 3.10+ this is safe across
+        sequential ``asyncio.run()`` calls (new event loop each time). On 3.9,
+        reuse across different loops is theoretically fragile; prefer one loop
+        per long-lived breaker until 3.9 support is dropped.
+        """
+        if self._async_lock is None:
+            with self._lock:
+                if self._async_lock is None:
+                    self._async_lock = asyncio.Lock()
+        return self._async_lock
 
     @property
     def fail_counter(self) -> int:
@@ -262,6 +279,21 @@ class CircuitBreaker:
             yield
 
         yield from self.call(_wrapper)
+
+    async def acall(self, func: Callable[..., Any], *args: Any, **kwargs: Any) -> Any:
+        """Call async (or awaitable-returning) ``func`` under the same state rules as
+        :meth:`call`, using :class:`asyncio.Lock` for mutual exclusion between
+        concurrent ``acall`` invocations.
+
+        ``func`` must be an ``async def`` or return an awaitable when invoked.
+        Sync generators, async generators, and Tornado coroutines are not
+        supported; use :meth:`call` / :meth:`call_async` instead.
+
+        Mixing :meth:`call` and ``acall`` on one instance is not guaranteed to
+        serialize; prefer one style per breaker where possible.
+        """
+        async with self._ensure_async_lock():
+            return await self.state.acall(func, *args, **kwargs)
 
     def call_async(self, func, *args, **kwargs):  # type: ignore[no-untyped-def]
         """Call async `func` with the given `args` and `kwargs` according to the rules
@@ -727,6 +759,30 @@ class CircuitBreakerState:
             self._handle_success()
         return ret
 
+    async def acall(self, func: Callable[..., Any], *args: Any, **kwargs: Any) -> Any:
+        """Async counterpart to :meth:`call` for ``async def`` and awaitable-returning callables."""
+        ret: Any = None
+
+        self.before_call(func, *args, **kwargs)
+        for listener in self._breaker.listeners:
+            listener.before_call(self._breaker, func, *args, **kwargs)
+
+        try:
+            ret = func(*args, **kwargs)
+            if inspect.isawaitable(ret):
+                ret = await ret
+        except BaseException as e:
+            self._handle_error(e)
+        else:
+            if isinstance(ret, types.GeneratorType):
+                msg = "acall does not support synchronous generators; use call() instead"
+                raise TypeError(msg)
+            if inspect.isasyncgen(ret):
+                msg = "acall does not support async generators; use an async function that returns a value"
+                raise TypeError(msg)
+            self._handle_success()
+        return ret
+
     def call_async(self, func, *args: Any, **kwargs: Any):  # type: ignore[no-untyped-def]
         """Call async `func` with the given `args` and `kwargs`, and updates the
         circuit breaker state according to the result.
@@ -856,6 +912,16 @@ class CircuitOpenState(CircuitBreakerState):
         the results from the call performed after the state is switch to half-open.
         """
         return self.before_call(func, *args, **kwargs)
+
+    async def acall(self, func: Callable[..., Any], *args: Any, **kwargs: Any) -> Any:
+        """After timeout, move to half-open and run the guarded operation via async path."""
+        timeout = timedelta(seconds=self._breaker.reset_timeout)
+        opened_at = self._breaker._state_storage.opened_at
+        if opened_at and datetime.now(UTC) < opened_at + timeout:
+            error_msg = "Timeout not elapsed yet, circuit breaker still open"
+            raise CircuitBreakerError(error_msg)
+        self._breaker.half_open()
+        return await self._breaker.state.acall(func, *args, **kwargs)
 
 
 class CircuitHalfOpenState(CircuitBreakerState):

--- a/src/pybreaker/__init__.py
+++ b/src/pybreaker/__init__.py
@@ -100,8 +100,16 @@ class CircuitBreaker:
         state_storage: CircuitBreakerStorage | None = None,
         name: str | None = None,
         throw_new_error_on_trip: bool = True,
+        fallback: Callable[..., Any] | None = None,
     ) -> None:
-        """Create a new circuit breaker with the given parameters."""
+        """Create a new circuit breaker with the given parameters.
+
+        If ``fallback`` is set, it is invoked (with the same ``*args`` and
+        ``**kwargs`` as the guarded call) when the circuit is **open** and the
+        reset timeout has not yet elapsed, instead of raising
+        ``CircuitBreakerError``. The primary callable is not run. For
+        :meth:`acall`, if ``fallback`` returns an awaitable, it is awaited.
+        """
         self._lock = threading.RLock()
         self._state_storage = state_storage or CircuitMemoryStorage(STATE_CLOSED)
         self._state = self._create_new_state(self.current_state)
@@ -115,6 +123,7 @@ class CircuitBreaker:
         self._name = name
 
         self._throw_new_error_on_trip = throw_new_error_on_trip
+        self._fallback = fallback
         self._async_lock: asyncio.Lock | None = None
 
     def _ensure_async_lock(self) -> asyncio.Lock:
@@ -259,6 +268,28 @@ class CircuitBreaker:
                 if exclusion(exception):
                     return False
         return True
+
+    def _open_circuit_fallback_or_raise(self, *args: Any, **kwargs: Any) -> Any:
+        """When open and timeout not elapsed: run ``fallback`` or raise ``CircuitBreakerError``."""
+        if self._fallback is None:
+            error_msg = "Timeout not elapsed yet, circuit breaker still open"
+            raise CircuitBreakerError(error_msg)
+        return self._fallback(*args, **kwargs)
+
+    async def _open_circuit_fallback_or_raise_async(self, *args: Any, **kwargs: Any) -> Any:
+        """Async variant of :meth:`_open_circuit_fallback_or_raise`."""
+        if self._fallback is None:
+            error_msg = "Timeout not elapsed yet, circuit breaker still open"
+            raise CircuitBreakerError(error_msg)
+        ret = self._fallback(*args, **kwargs)
+        if inspect.isawaitable(ret):
+            return await ret
+        return ret
+
+    @property
+    def fallback(self) -> Callable[..., Any] | None:
+        """Optional callable used when the circuit is open and the reset timeout has not elapsed."""
+        return self._fallback
 
     def call(self, func: Callable[..., T], *args: Any, **kwargs: Any) -> T:
         """Call `func` with the given `args` and `kwargs` according to the rules
@@ -910,20 +941,19 @@ class CircuitOpenState(CircuitBreakerState):
             for listener in self._breaker.listeners:
                 listener.state_change(self._breaker, prev_state, self)
 
-    def before_call(self, func: Callable[..., T], *args: Any, **kwargs: Any) -> T:
+    def before_call(self, func: Callable[..., T], *args: Any, **kwargs: Any) -> Any:
         """After the timeout elapses, move the circuit breaker to the "half-open"
         state; otherwise, raises ``CircuitBreakerError`` without any attempt
-        to execute the real operation.
+        to execute the real operation (unless a ``fallback`` is configured).
         """
         timeout = timedelta(seconds=self._breaker.reset_timeout)
         opened_at = self._breaker._state_storage.opened_at
         if opened_at and datetime.now(UTC) < opened_at + timeout:
-            error_msg = "Timeout not elapsed yet, circuit breaker still open"
-            raise CircuitBreakerError(error_msg)
+            return self._breaker._open_circuit_fallback_or_raise(*args, **kwargs)
         self._breaker.half_open()
         return self._breaker.call(func, *args, **kwargs)
 
-    def call(self, func: Callable[..., T], *args: Any, **kwargs: Any) -> T:
+    def call(self, func: Callable[..., T], *args: Any, **kwargs: Any) -> Any:
         """Delegate the call to before_call, if the time out is not elapsed it will throw an exception, otherwise we get
         the results from the call performed after the state is switch to half-open.
         """
@@ -934,8 +964,7 @@ class CircuitOpenState(CircuitBreakerState):
         timeout = timedelta(seconds=self._breaker.reset_timeout)
         opened_at = self._breaker._state_storage.opened_at
         if opened_at and datetime.now(UTC) < opened_at + timeout:
-            error_msg = "Timeout not elapsed yet, circuit breaker still open"
-            raise CircuitBreakerError(error_msg)
+            return await self._breaker._open_circuit_fallback_or_raise_async(*args, **kwargs)
         self._breaker.half_open()
         return await self._breaker.state.acall(func, *args, **kwargs)
 

--- a/tests/pybreaker_test.py
+++ b/tests/pybreaker_test.py
@@ -1616,5 +1616,136 @@ class CircuitBreakerAsyncioTestCase(unittest.TestCase):
         asyncio.run(run())
 
 
+class CircuitBreakerFallbackTestCase(unittest.TestCase):
+    """Open-circuit short-circuit: optional ``fallback`` (Hystrix-style)."""
+
+    def test_call_open_returns_fallback_value(self):
+        def primary():
+            raise AssertionError("primary must not run when open")
+
+        breaker = CircuitBreaker(
+            fail_max=1,
+            reset_timeout=300,
+            throw_new_error_on_trip=False,
+            fallback=lambda x: f"fb-{x}",
+        )
+
+        def err():
+            raise RuntimeError("trip")
+
+        with pytest.raises(RuntimeError):
+            breaker.call(err)
+        assert breaker.current_state == "open"
+
+        assert breaker.call(primary, 42) == "fb-42"
+
+    def test_call_open_without_fallback_raises(self):
+        breaker = CircuitBreaker(fail_max=1, reset_timeout=300, throw_new_error_on_trip=False)
+
+        def err():
+            raise RuntimeError("trip")
+
+        with pytest.raises(RuntimeError):
+            breaker.call(err)
+
+        def primary():
+            return True
+
+        with pytest.raises(CircuitBreakerError, match="Timeout not elapsed"):
+            breaker.call(primary)
+
+    def test_fallback_receives_kwargs(self):
+        breaker = CircuitBreaker(
+            fail_max=1,
+            reset_timeout=300,
+            throw_new_error_on_trip=False,
+            fallback=lambda **kw: kw["a"] + kw["b"],
+        )
+
+        def err():
+            raise RuntimeError("trip")
+
+        with pytest.raises(RuntimeError):
+            breaker.call(err)
+
+        def primary():
+            return None
+
+        assert breaker.call(primary, a=1, b=2) == 3
+
+    def test_fallback_property(self):
+        def fb():
+            return 1
+
+        b = CircuitBreaker(fallback=fb)
+        assert b.fallback is fb
+        b2 = CircuitBreaker()
+        assert b2.fallback is None
+
+    def test_acall_open_sync_fallback(self):
+        breaker = CircuitBreaker(
+            fail_max=1,
+            reset_timeout=300,
+            throw_new_error_on_trip=False,
+            fallback=lambda x: x * 10,
+        )
+
+        def err():
+            raise ValueError("trip")
+
+        with pytest.raises(ValueError, match="trip"):
+            breaker.call(err)
+
+        async def primary():
+            raise AssertionError("primary must not run")
+
+        assert asyncio.run(breaker.acall(primary, 7)) == 70
+
+    def test_acall_open_async_fallback(self):
+        async def async_fb(n):
+            return n * 2
+
+        breaker = CircuitBreaker(
+            fail_max=1,
+            reset_timeout=300,
+            throw_new_error_on_trip=False,
+            fallback=async_fb,
+        )
+
+        def err():
+            raise ValueError("trip")
+
+        with pytest.raises(ValueError):
+            breaker.call(err)
+
+        async def primary():
+            raise AssertionError("primary must not run")
+
+        assert asyncio.run(breaker.acall(primary, 11)) == 22
+
+    def test_fallback_that_raises_propagates(self):
+        def bad_fallback():
+            raise ConnectionError("fallback failed")
+
+        breaker = CircuitBreaker(
+            fail_max=1,
+            reset_timeout=300,
+            throw_new_error_on_trip=False,
+            fallback=bad_fallback,
+        )
+
+        def err():
+            raise RuntimeError("trip")
+
+        with pytest.raises(RuntimeError):
+            breaker.call(err)
+        assert breaker.current_state == "open"
+
+        with pytest.raises(ConnectionError, match="fallback failed"):
+            breaker.call(lambda: None)
+        assert breaker.current_state == "open"
+        assert breaker.fail_counter == 1
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/pybreaker_test.py
+++ b/tests/pybreaker_test.py
@@ -734,6 +734,44 @@ class CircuitBreakerConfigurationTestCase:
 
             self.breaker(func, __pybreaker_call_async=True)
 
+    def test_decorator_call_acall(self):
+        """CircuitBreaker: decorator with __pybreaker_call_acall wraps async functions."""
+
+        @self.breaker(__pybreaker_call_acall=True)
+        async def suc(value):
+            """Docstring"""
+            return value
+
+        @self.breaker(__pybreaker_call_acall=True)
+        async def err(value):
+            """Docstring"""
+            raise NotImplementedError
+
+        assert suc.__doc__ == "Docstring"
+        assert err.__doc__ == "Docstring"
+        assert suc.__name__ == "suc"
+        assert err.__name__ == "err"
+
+        async def run():
+            with pytest.raises(NotImplementedError):
+                await err(True)
+            assert self.breaker.fail_counter == 1
+            assert await suc(True)
+            assert self.breaker.fail_counter == 0
+
+        asyncio.run(run())
+
+    def test_partial_breaker_call_acall(self):
+        async def func(x):
+            return x + 1
+
+        wrapped = self.breaker(func, __pybreaker_call_acall=True)
+        assert asyncio.run(wrapped(1)) == 2
+
+    def test_both_pybreaker_async_flags_raises(self):
+        with pytest.raises(ValueError, match="Cannot set both"):
+            self.breaker(__pybreaker_call_async=True, __pybreaker_call_acall=True)
+
     def test_name(self):
         """CircuitBreaker: it should allow an optional name to be set and
         retrieved.

--- a/tests/pybreaker_test.py
+++ b/tests/pybreaker_test.py
@@ -1,3 +1,4 @@
+import asyncio
 import unittest
 from contextlib import contextmanager
 from datetime import datetime
@@ -1350,6 +1351,231 @@ class CircuitBreakerContextManagerTestCase(unittest.TestCase):
         mock_fn.assert_called_once()
         assert breaker.fail_counter == 0
         assert breaker.current_state == "closed"
+
+
+class CircuitBreakerAsyncioTestCase(unittest.TestCase):
+    """Tests for native asyncio :meth:`CircuitBreaker.acall` (PR 1: core API only)."""
+
+    def test_acall_success_closed(self):
+        breaker = CircuitBreaker()
+
+        async def ok():
+            return 42
+
+        assert asyncio.run(breaker.acall(ok)) == 42
+        assert breaker.fail_counter == 0
+        assert breaker.current_state == "closed"
+
+    def test_acall_with_args(self):
+        breaker = CircuitBreaker()
+
+        async def add(a, b):
+            return a + b
+
+        assert asyncio.run(breaker.acall(add, 40, 2)) == 42
+
+    def test_acall_with_kwargs(self):
+        breaker = CircuitBreaker()
+
+        async def merge(**kwargs):
+            return kwargs
+
+        assert asyncio.run(breaker.acall(merge, a=1, b=2)) == {"a": 1, "b": 2}
+
+    def test_acall_listener_callbacks(self):
+        breaker = CircuitBreaker()
+
+        class RecordingListener(CircuitBreakerListener):
+            def __init__(self) -> None:
+                self.before = 0
+                self.successes = 0
+                self.failures = 0
+
+            def before_call(self, cb, func, *args, **kwargs):
+                self.before += 1
+
+            def success(self, cb):
+                self.successes += 1
+
+            def failure(self, cb, exc):
+                self.failures += 1
+
+        listener = RecordingListener()
+        breaker.add_listener(listener)
+
+        async def ok():
+            return 1
+
+        async def bad():
+            raise ValueError("x")
+
+        async def run():
+            assert await breaker.acall(ok) == 1
+            with pytest.raises(ValueError):
+                await breaker.acall(bad)
+
+        asyncio.run(run())
+        assert listener.before == 2
+        assert listener.successes == 1
+        assert listener.failures == 1
+
+    def test_acall_failures_open_circuit(self):
+        breaker = CircuitBreaker(fail_max=3)
+
+        async def err():
+            raise NotImplementedError
+
+        async def run_fails():
+            with pytest.raises(NotImplementedError):
+                await breaker.acall(err)
+            with pytest.raises(NotImplementedError):
+                await breaker.acall(err)
+            with pytest.raises(CircuitBreakerError):
+                await breaker.acall(err)
+
+        asyncio.run(run_fails())
+        assert breaker.fail_counter == 3
+        assert breaker.current_state == "open"
+
+    def test_acall_throw_new_error_on_trip_false(self):
+        breaker = CircuitBreaker(fail_max=3, throw_new_error_on_trip=False)
+
+        async def err():
+            raise NotImplementedError
+
+        async def run_all():
+            with pytest.raises(NotImplementedError):
+                await breaker.acall(err)
+            with pytest.raises(NotImplementedError):
+                await breaker.acall(err)
+            with pytest.raises(NotImplementedError):
+                await breaker.acall(err)
+
+        asyncio.run(run_all())
+        assert breaker.fail_counter == 3
+        assert breaker.current_state == "open"
+
+    def test_acall_open_raises_until_timeout(self):
+        # fail_max=1 trips on first failure with CircuitBreakerError by default;
+        # use throw_new_error_on_trip=False so the original error propagates once.
+        breaker = CircuitBreaker(fail_max=1, reset_timeout=60, throw_new_error_on_trip=False)
+
+        async def err():
+            raise RuntimeError("boom")
+
+        async def trip():
+            with pytest.raises(RuntimeError, match="boom"):
+                await breaker.acall(err)
+
+        asyncio.run(trip())
+        assert breaker.current_state == "open"
+
+        async def blocked():
+            with pytest.raises(CircuitBreakerError, match="Timeout not elapsed"):
+                await breaker.acall(err)
+
+        asyncio.run(blocked())
+
+    def test_acall_recovery_after_reset_timeout(self):
+        breaker = CircuitBreaker(fail_max=1, reset_timeout=0.01, throw_new_error_on_trip=False)
+
+        async def err():
+            raise NotImplementedError
+
+        async def ok():
+            return True
+
+        async def run():
+            with pytest.raises(NotImplementedError):
+                await breaker.acall(err)
+            assert breaker.current_state == "open"
+            await asyncio.sleep(0.02)
+            assert await breaker.acall(ok)
+            assert breaker.current_state == "closed"
+            assert breaker.fail_counter == 0
+
+        asyncio.run(run())
+
+    def test_acall_excluded_exceptions(self):
+        breaker = CircuitBreaker(exclude=[LookupError])
+
+        async def err_sys():
+            raise NotImplementedError
+
+        async def err_biz():
+            raise LookupError
+
+        async def run():
+            with pytest.raises(NotImplementedError):
+                await breaker.acall(err_sys)
+            assert breaker.fail_counter == 1
+            with pytest.raises(LookupError):
+                await breaker.acall(err_biz)
+            assert breaker.fail_counter == 0
+
+        asyncio.run(run())
+
+    def test_acall_rejects_sync_generator(self):
+        breaker = CircuitBreaker()
+
+        def gen():
+            yield 1
+
+        async def run():
+            with pytest.raises(TypeError, match="acall does not support"):
+                await breaker.acall(gen)
+
+        asyncio.run(run())
+        assert breaker.fail_counter == 0
+        assert breaker.current_state == "closed"
+
+    def test_acall_rejects_async_generator(self):
+        breaker = CircuitBreaker()
+
+        async def agen():
+            yield 1
+
+        async def run():
+            with pytest.raises(TypeError, match="async generators"):
+                await breaker.acall(agen)
+
+        asyncio.run(run())
+        assert breaker.fail_counter == 0
+        assert breaker.current_state == "closed"
+
+    def test_acall_half_open_failure_raises_circuit_breaker_error(self):
+        """Default throw_new_error_on_trip: half-open trial failure surfaces CircuitBreakerError."""
+        breaker = CircuitBreaker(fail_max=1, reset_timeout=0.01)
+
+        async def err():
+            raise NotImplementedError
+
+        async def run():
+            with pytest.raises(CircuitBreakerError, match="Failures threshold"):
+                await breaker.acall(err)
+            await asyncio.sleep(0.02)
+            with pytest.raises(CircuitBreakerError, match="Trial call failed"):
+                await breaker.acall(err)
+            assert breaker.current_state == "open"
+
+        asyncio.run(run())
+
+    def test_acall_half_open_failure_reopens_with_original_error(self):
+        """With throw_new_error_on_trip=False, half-open trial failure re-raises the call error."""
+        breaker = CircuitBreaker(fail_max=1, reset_timeout=0.01, throw_new_error_on_trip=False)
+
+        async def err():
+            raise NotImplementedError
+
+        async def run():
+            with pytest.raises(NotImplementedError):
+                await breaker.acall(err)
+            await asyncio.sleep(0.02)
+            with pytest.raises(NotImplementedError):
+                await breaker.acall(err)
+            assert breaker.current_state == "open"
+
+        asyncio.run(run())
 
 
 if __name__ == "__main__":

--- a/tests/typechecks.py
+++ b/tests/typechecks.py
@@ -8,3 +8,10 @@ CircuitBreaker(
     exclude=[lambda e: isinstance(e, RuntimeError)],
     state_storage=CircuitMemoryStorage(STATE_CLOSED),
 )
+
+CircuitBreaker(
+    fail_max=1,
+    reset_timeout=1000,
+    fallback=lambda *args, **kwargs: None,
+    state_storage=CircuitMemoryStorage(STATE_CLOSED),
+)


### PR DESCRIPTION
## Summary

Adds an optional `fallback` parameter to `CircuitBreaker`. When the circuit is open and a fallback is provided, it is called with the original arguments instead of raising `CircuitBreakerError`. Works for both sync (`call`) and async (`acall`) paths, including awaiting async fallbacks. Purely opt-in — omitting it preserves existing raise-on-open behaviour.

Depends on #103 and the decorator/docs PR being merged first.

## What changed

- `CircuitBreaker.__init__` accepts `fallback: Callable | None`.
- New `_open_circuit_fallback_or_raise` (sync) and `_open_circuit_fallback_or_raise_async` methods.
- `CircuitOpenState.before_call` and `CircuitOpenState.acall` delegate to fallback helpers when the timeout has not elapsed.
- `fallback` read-only property.
- README section documenting the feature with examples.
- CHANGELOG entry.
- 7 new test cases (sync fallback, no-fallback raise, kwargs forwarding, property, async+sync fallback, async+async fallback, fallback-that-raises propagation).
- `tests/typechecks.py` updated for mypy coverage.

## Test plan

- [x] All 103 tests pass
- [x] mypy and ruff clean
