### PR TITLE
fix: replace Python 2 print statement with print() in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -315,7 +315,7 @@ change its current state:
     db_breaker.success_threshold = 3
 
     # Get/set the current reset timeout period (in seconds)
-    print db_breaker.reset_timeout
+    print(db_breaker.reset_timeout)
     db_breaker.reset_timeout = 60
 
     # Get the current state, i.e., 'open', 'half-open', 'closed'


### PR DESCRIPTION
Found a small bug while reading the README: one of the example lines under the 'Monitoring and Management' section uses Python 2 print-statement syntax:

```python
# Get/set the current reset timeout period (in seconds)
print db_breaker.reset_timeout
```

This won't run on Python 3 (the project requires Python 3.10+, having dropped support for older versions back in 1.2.0). Every other `print` example in the same block correctly uses `print(...)`.

### Before
```python
# Get/set the current reset timeout period (in seconds)
print db_breaker.reset_timeout
db_breaker.reset_timeout = 60
```

### After
```python
# Get/set the current reset timeout period (in seconds)
print(db_breaker.reset_timeout)
db_breaker.reset_timeout = 60
```

Single-line change, no code or behavior touched.

— Sent via @AmSach bot